### PR TITLE
new: make authorizer usable over the API

### DIFF
--- a/cmd/a3s/main.go
+++ b/cmd/a3s/main.go
@@ -158,7 +158,7 @@ func main() {
 				pauthz,
 			},
 		),
-		bahamut.OptPushDispatchHandler(authorizer.NewPushDispatchHandler(m, pauthz)),
+		bahamut.OptPushDispatchHandler(authorizer.NewPushDispatchHandler(pauthz)),
 		bahamut.OptPushPublishHandler(bootstrap.MakePublishHandler(nil)),
 		bahamut.OptMTLS(nil, tls.RequestClientCert),
 		bahamut.OptErrorTransformer(errorTransformer),

--- a/pkgs/authorizer/authorizer.go
+++ b/pkgs/authorizer/authorizer.go
@@ -63,7 +63,7 @@ type authorizer struct {
 	cache            *nscache.NamespacedCache
 }
 
-// New creates a new Authorizer using cid.
+// New creates a new Authorizer.
 func New(ctx context.Context, retriever permissions.Retriever, pubsub bahamut.PubSubClient, options ...Option) Authorizer {
 
 	cfg := config{}

--- a/pkgs/authorizer/pubsub.go
+++ b/pkgs/authorizer/pubsub.go
@@ -1,0 +1,103 @@
+package authorizer
+
+import (
+	"context"
+
+	"go.aporeto.io/a3s/pkgs/api"
+	"go.aporeto.io/a3s/pkgs/notification"
+	"go.aporeto.io/a3s/pkgs/nscache"
+	"go.aporeto.io/bahamut"
+	"go.aporeto.io/manipulate"
+)
+
+type eventData struct {
+	Namespace string `json:"namespace" msgpack:"namespace"`
+	Name      string `json:"name" msgpack:"name"`
+}
+
+// webSocketPubSub is a naive bahamut.PubSubClient internal implementation
+// that is backed by a manipulate.Subscriber. This is used to
+// make the Authorizer working when used by third party clients that
+// won't have access to the internal NATS notification topic.
+// It basically acts a shim layer that translates classic elemental.Events
+// into the relevant notification.Message used by the authorizer internal
+// namespace cache.
+type webSocketPubSub struct {
+	subscriber manipulate.Subscriber
+}
+
+// not implemented. These are just here to satisfy the bahamut.PubSubClient interface.
+func (w *webSocketPubSub) Connect(context.Context) error { return nil }
+func (w *webSocketPubSub) Disconnect() error             { return nil }
+func (w *webSocketPubSub) Publish(*bahamut.Publication, ...bahamut.PubSubOptPublish) error {
+	return nil
+}
+
+func (w *webSocketPubSub) Subscribe(pubs chan *bahamut.Publication, errors chan error, topic string, opts ...bahamut.PubSubOptSubscribe) func() {
+
+	sendErr := func(err error) {
+		select {
+		case errors <- err:
+		default:
+		}
+	}
+
+	sendPub := func(pub *bahamut.Publication) {
+		select {
+		case pubs <- pub:
+		default:
+		}
+	}
+
+	go func() {
+
+		for {
+			select {
+
+			case evt := <-w.subscriber.Events():
+
+				// We decode the vent in a generic container structure.
+				d := &eventData{}
+				if err := evt.Decode(d); err != nil {
+					sendErr(err)
+					break
+				}
+
+				// We prepare a notification Message that the authorizer
+				// nscache will understand.
+				msg := notification.Message{
+					Type: nscache.NotificationNamespaceChanges,
+				}
+
+				// We populate the namespace name based on the
+				// event identity.
+				switch evt.Identity {
+				case api.NamespaceIdentity.Name:
+					msg.Data = d.Name
+				case api.AuthorizationIdentity.Name:
+					msg.Data = d.Namespace
+				}
+
+				// Then we create a publication and wrap the msg inside.
+				p := bahamut.NewPublication(topic)
+				if err := p.Encode(msg); err != nil {
+					sendErr(err)
+					break
+				}
+
+				sendPub(p)
+
+			case st := <-w.subscriber.Status():
+				if st == manipulate.SubscriberStatusFinalDisconnection {
+					return
+				}
+
+			case err := <-w.subscriber.Errors():
+				sendErr(err)
+			}
+		}
+
+	}()
+
+	return nil
+}

--- a/pkgs/authorizer/pubsub_test.go
+++ b/pkgs/authorizer/pubsub_test.go
@@ -49,7 +49,7 @@ func TestSubscribe(t *testing.T) {
 		checkPresent := func(chOutPubs chan *bahamut.Publication) {
 			pub := <-chOutPubs
 			msg := notification.Message{}
-			pub.Decode(&msg)
+			pub.Decode(&msg) // nolint
 			So(msg.Type, ShouldEqual, nscache.NotificationNamespaceChanges)
 			So(msg.Data, ShouldEqual, "/the/ns")
 		}

--- a/pkgs/authorizer/pubsub_test.go
+++ b/pkgs/authorizer/pubsub_test.go
@@ -1,0 +1,99 @@
+package authorizer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/a3s/pkgs/api"
+	"go.aporeto.io/a3s/pkgs/notification"
+	"go.aporeto.io/a3s/pkgs/nscache"
+	"go.aporeto.io/bahamut"
+	"go.aporeto.io/elemental"
+	"go.aporeto.io/manipulate"
+	"go.aporeto.io/manipulate/maniptest"
+)
+
+func TestNotImplemented(t *testing.T) {
+	// free coverage \o/
+	Convey("Given an authorizer", t, func() {
+		s := webSocketPubSub{}
+		So(s.Connect(context.Background()), ShouldBeNil)
+		So(s.Disconnect(), ShouldBeNil)
+		So(s.Publish(nil), ShouldBeNil)
+	})
+}
+
+func TestSubscribe(t *testing.T) {
+
+	Convey("I have a subscriber and a ws authorizer", t, func() {
+
+		s := maniptest.NewTestSubscriber()
+		a := webSocketPubSub{subscriber: s}
+		chInEvents := make(chan *elemental.Event, 2)
+		chInStatus := make(chan manipulate.SubscriberStatus, 2)
+		chInErrors := make(chan error, 2)
+
+		s.MockEvents(t, func() chan *elemental.Event {
+			return chInEvents
+		})
+		s.MockStatus(t, func() chan manipulate.SubscriberStatus {
+			return chInStatus
+		})
+		s.MockErrors(t, func() chan error {
+			return chInErrors
+		})
+
+		checkPresent := func(chOutPubs chan *bahamut.Publication) {
+			pub := <-chOutPubs
+			msg := notification.Message{}
+			pub.Decode(&msg)
+			So(msg.Type, ShouldEqual, nscache.NotificationNamespaceChanges)
+			So(msg.Data, ShouldEqual, "/the/ns")
+		}
+
+		Convey("when I receive a push from a namespace", func() {
+			chOutPubs := make(chan *bahamut.Publication, 2)
+			chOutErrs := make(chan error, 2)
+			a.Subscribe(chOutPubs, chOutErrs, "topic")
+			chInEvents <- elemental.NewEvent(elemental.EventUpdate, &api.Namespace{Name: "/the/ns"})
+			checkPresent(chOutPubs)
+		})
+
+		Convey("when I receive a push from a authorization", func() {
+			chOutPubs := make(chan *bahamut.Publication, 2)
+			chOutErrs := make(chan error, 2)
+			a.Subscribe(chOutPubs, chOutErrs, "topic")
+			chInEvents <- elemental.NewEvent(elemental.EventUpdate, &api.Authorization{Namespace: "/the/ns"})
+			checkPresent(chOutPubs)
+		})
+
+		Convey("when I receive an error", func() {
+			chOutPubs := make(chan *bahamut.Publication, 2)
+			chOutErrs := make(chan error, 2)
+			a.Subscribe(chOutPubs, chOutErrs, "topic")
+			chInErrors <- fmt.Errorf("boom")
+			e := <-chOutErrs
+			So(e.Error(), ShouldEqual, "boom")
+		})
+
+		Convey("when I receive a final disconnect", func() {
+			chOutPubs := make(chan *bahamut.Publication, 2)
+			chOutErrs := make(chan error, 2)
+			a.Subscribe(chOutPubs, chOutErrs, "topic")
+			chInStatus <- manipulate.SubscriberStatusFinalDisconnection
+			time.Sleep(300 * time.Millisecond)
+		})
+
+		Convey("when the even it not decodable", func() {
+			chOutPubs := make(chan *bahamut.Publication, 2)
+			chOutErrs := make(chan error, 2)
+			a.Subscribe(chOutPubs, chOutErrs, "topic")
+			chInEvents <- &elemental.Event{RawData: []byte("oh no")}
+			e := <-chOutErrs
+			So(e.Error(), ShouldEqual, "unable to decode application/json: EOF")
+		})
+	})
+}

--- a/pkgs/authorizer/push.go
+++ b/pkgs/authorizer/push.go
@@ -8,7 +8,6 @@ import (
 	"go.aporeto.io/a3s/pkgs/token"
 	"go.aporeto.io/bahamut"
 	"go.aporeto.io/elemental"
-	"go.aporeto.io/manipulate"
 	"go.uber.org/zap"
 )
 
@@ -24,16 +23,14 @@ type pushedEntity struct {
 
 // A PushDispatchHandler handles dispatching events to push sessions.
 type PushDispatchHandler struct {
-	authorizer  Authorizer
-	manipulator manipulate.Manipulator
+	authorizer Authorizer
 }
 
 // NewPushDispatchHandler returns a new PushDispatchHandler.
-func NewPushDispatchHandler(manipulator manipulate.Manipulator, authorizer Authorizer) *PushDispatchHandler {
+func NewPushDispatchHandler(authorizer Authorizer) *PushDispatchHandler {
 
 	return &PushDispatchHandler{
-		manipulator: manipulator,
-		authorizer:  authorizer,
+		authorizer: authorizer,
 	}
 }
 

--- a/pkgs/authorizer/push_test.go
+++ b/pkgs/authorizer/push_test.go
@@ -23,9 +23,8 @@ func TestNewPushDispatcher(t *testing.T) {
 		_ = p.Connect(context.Background())
 		r := permissions.NewRetriever(m)
 		a := New(context.Background(), r, p)
-		h := NewPushDispatchHandler(m, a)
+		h := NewPushDispatchHandler(a)
 
-		So(h.manipulator, ShouldEqual, m)
 		So(func() { h.OnPushSessionStart(bahamut.NewMockSession()) }, ShouldNotPanic)
 		So(func() { h.OnPushSessionStop(bahamut.NewMockSession()) }, ShouldNotPanic)
 	})
@@ -37,12 +36,11 @@ func TestOnPushSessionInit(t *testing.T) {
 
 		_, key := getECCert()
 
-		m := maniptest.NewTestManipulator()
 		p := bahamut.NewLocalPubSubClient()
 		_ = p.Connect(context.Background())
 		r := permissions.NewMockRetriever()
 		a := New(context.Background(), r, p)
-		h := NewPushDispatchHandler(m, a)
+		h := NewPushDispatchHandler(a)
 
 		Convey("When there are bad restrictions in the token ", func() {
 
@@ -119,12 +117,11 @@ func TestSummarizeEvent(t *testing.T) {
 
 	Convey("Given I have a push handler", t, func() {
 
-		m := maniptest.NewTestManipulator()
 		p := bahamut.NewLocalPubSubClient()
 		_ = p.Connect(context.Background())
 		r := permissions.NewMockRetriever()
 		a := New(context.Background(), r, p)
-		h := NewPushDispatchHandler(m, a)
+		h := NewPushDispatchHandler(a)
 
 		Convey("Calling SummarizeEvent with an valid event should work", func() {
 
@@ -153,12 +150,11 @@ func TestShouldDispatch(t *testing.T) {
 
 		_, key := getECCert()
 
-		m := maniptest.NewTestManipulator()
 		p := bahamut.NewLocalPubSubClient()
 		_ = p.Connect(context.Background())
 		r := permissions.NewMockRetriever()
 		a := New(context.Background(), r, p)
-		h := NewPushDispatchHandler(m, a)
+		h := NewPushDispatchHandler(a)
 
 		Convey("When we receive a namespace delete event", func() {
 

--- a/pkgs/authorizer/remote.go
+++ b/pkgs/authorizer/remote.go
@@ -1,0 +1,38 @@
+package authorizer
+
+import (
+	"context"
+
+	"go.aporeto.io/a3s/pkgs/api"
+	"go.aporeto.io/a3s/pkgs/permissions"
+	"go.aporeto.io/elemental"
+	"go.aporeto.io/manipulate"
+	"go.aporeto.io/manipulate/maniphttp"
+)
+
+type remoteAuthorizer struct {
+	Authorizer
+}
+
+// NewRemote returns a ready to use bahamut.Authorizer that can be used over the API.
+// This is meant to be use by external bahamut service.
+// Updates of the namespace/authorization state comes from the websocket.
+func NewRemote(ctx context.Context, m manipulate.Manipulator, options ...Option) Authorizer {
+
+	subscriber := maniphttp.NewSubscriber(m, maniphttp.SubscriberOptionRecursive(true))
+
+	pcfg := elemental.NewPushConfig()
+	pcfg.FilterIdentity(api.NamespaceIdentity.Name)
+	pcfg.FilterIdentity(api.AuthorizationIdentity.Name)
+
+	subscriber.Start(ctx, pcfg)
+
+	return &remoteAuthorizer{
+		Authorizer: New(
+			ctx,
+			permissions.NewRemoteRetriever(m),
+			&webSocketPubSub{subscriber: subscriber},
+			options...,
+		),
+	}
+}

--- a/pkgs/authorizer/remote.go
+++ b/pkgs/authorizer/remote.go
@@ -19,7 +19,11 @@ type remoteAuthorizer struct {
 // Updates of the namespace/authorization state comes from the websocket.
 func NewRemote(ctx context.Context, m manipulate.Manipulator, options ...Option) Authorizer {
 
-	subscriber := maniphttp.NewSubscriber(m, maniphttp.SubscriberOptionRecursive(true))
+	subscriber := maniphttp.NewSubscriber(
+		m,
+		maniphttp.SubscriberOptionRecursive(true),
+		maniphttp.SubscriberOptionNamespace(maniphttp.ExtractNamespace(m)),
+	)
 
 	pcfg := elemental.NewPushConfig()
 	pcfg.FilterIdentity(api.NamespaceIdentity.Name)


### PR DESCRIPTION
Adds the necessary code to allow using the Authorizer through the API, using websocket as event bus