### PR TITLE
new: add helpers to securely forward user certificates from a gateway

### DIFF
--- a/pkgs/gwutils/gwutils.go
+++ b/pkgs/gwutils/gwutils.go
@@ -59,8 +59,8 @@ func MakeTLSPeerCertificateVerifier(
 			return fmt.Errorf("tls: failed to parse certificate from server: %w", err)
 		}
 
-		authorityKeyId := fmt.Sprintf("%02X", cert.AuthorityKeyId)
-		item := cache.Get(authorityKeyId)
+		authorityKeyID := fmt.Sprintf("%02X", cert.AuthorityKeyId)
+		item := cache.Get(authorityKeyID)
 		var pool *x509.CertPool
 
 		if item == nil || item.Expired() {
@@ -72,7 +72,7 @@ func MakeTLSPeerCertificateVerifier(
 				tctx,
 				manipulate.ContextOptionFilter(
 					elemental.NewFilterComposer().
-						WithKey("subjectKeyIDs").Equals(authorityKeyId).
+						WithKey("subjectKeyIDs").Equals(authorityKeyID).
 						Done(),
 				),
 			)
@@ -92,7 +92,7 @@ func MakeTLSPeerCertificateVerifier(
 
 			pool = x509.NewCertPool()
 			pool.AppendCertsFromPEM([]byte(sources[0].CA))
-			cache.Set(authorityKeyId, pool, cfg.cacheDuration)
+			cache.Set(authorityKeyID, pool, cfg.cacheDuration)
 		} else {
 			pool = item.Value().(*x509.CertPool)
 		}

--- a/pkgs/gwutils/gwutils.go
+++ b/pkgs/gwutils/gwutils.go
@@ -1,0 +1,165 @@
+package gwutils
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/karlseguin/ccache/v2"
+	"go.aporeto.io/a3s/pkgs/api"
+	"go.aporeto.io/a3s/pkgs/token"
+	"go.aporeto.io/bahamut/gateway"
+	"go.aporeto.io/elemental"
+	"go.aporeto.io/manipulate"
+	"go.aporeto.io/tg/tglib"
+)
+
+// MakeTLSVerifyPeerCertificate returns a function you can use as
+// tls.Config.VerifyPeerCertificate. You will need to do this if you want to
+// support user authentication through MTLS while you are behind a
+// bahamut.Gateway.
+//
+// This is the first step of the necessary dance to securely forward the client
+// certificate in a trusted header. You will then need to add an interceptor
+// using MakeTLSPeerCertificateForwarder
+//
+// The returned function will use the provided manipulator to search A3S for an
+// mtls source that holds the CA that has issued the presented client
+// certificates by matching the certificate AuthorityKeyID. If it can find one,
+// the certificate signature will be checked using the matching CA.
+//
+// The results are cached for the provided cacheDuration and a maximum of
+// cacheSize items will be kept.
+func MakeTLSVerifyPeerCertificate(
+	m manipulate.Manipulator,
+	cacheSize int64,
+	cacheDuration time.Duration,
+) func([][]byte, [][]*x509.Certificate) error {
+
+	cache := ccache.New(ccache.Configure().MaxSize(cacheSize))
+
+	return func(
+		rawCerts [][]byte,
+		verifiedChains [][]*x509.Certificate,
+	) error {
+
+		if len(rawCerts) == 0 {
+			return nil
+		}
+
+		cert, err := x509.ParseCertificate(rawCerts[0])
+		if err != nil {
+			return fmt.Errorf("tls: failed to parse certificate from server: %w", err)
+		}
+
+		authorityKeyId := token.Fingerprint(cert)
+		item := cache.Get(authorityKeyId)
+		var pool *x509.CertPool
+
+		if item == nil || item.Expired() {
+
+			mctx := manipulate.NewContext(
+				context.Background(),
+				manipulate.ContextOptionFilter(
+					elemental.NewFilterComposer().
+						WithKey("subjectKeyIDs").Equals(authorityKeyId).
+						Done(),
+				),
+			)
+
+			sources := api.MTLSSourcesList{}
+			if err := m.RetrieveMany(mctx, &sources); err != nil {
+				return fmt.Errorf("unable to retrieve mtlssources: %w", err)
+			}
+
+			switch len(sources) {
+			case 0:
+				return fmt.Errorf("unable to retrieve any matching mtlssource")
+			case 1:
+			default:
+				return fmt.Errorf("more than one mtls sources hold the signing CA. this is not supported")
+			}
+
+			pool = x509.NewCertPool()
+			pool.AppendCertsFromPEM([]byte(sources[0].CA))
+			cache.Set(authorityKeyId, pool, cacheDuration)
+		} else {
+			pool = item.Value().(*x509.CertPool)
+		}
+
+		if _, err := cert.Verify(
+			x509.VerifyOptions{
+				Roots: pool,
+				KeyUsages: []x509.ExtKeyUsage{
+					x509.ExtKeyUsageClientAuth,
+				},
+			},
+		); err != nil {
+			return fmt.Errorf("unable to validate client certificate: %w", err)
+		}
+
+		return nil
+	}
+}
+
+// MakeTLSPeerCertificateForwarder returns a bahamut gateway.InterceptorFunc
+// that you will need to add to the bahamut.Gateway in order to intercept any
+// calls going to the A3S /issue endpoint (or any other one you would have as a
+// proxy) in order to pass the user certificates as a secure header.
+//
+// The encryptionPassphrase is necessary as A3S will refuse to trust a header
+// containing a user certificate if it is not encrypted with that key. The key
+// must be exactly 16, 24 or 32 bytes long to encrypt respectively to AES-128,
+// A3S-192 or AES-256.
+//
+// WARNING: You MUST NOT use this function without installing a custom peer
+// certificate verifier with MakeTLSVerifyPeerCertificate in the gateway's
+// server TLS config. A3S will blindly trust the certificate in the header,
+// which is why you MUST verify it before.
+func MakeTLSPeerCertificateForwarder(
+	encryptionPassphrase string,
+) gateway.InterceptorFunc {
+
+	return func(
+		w http.ResponseWriter,
+		req *http.Request,
+		writeError gateway.ErrorWriter,
+		corsInjector func(),
+	) (gateway.InterceptorAction, string, error) {
+
+		if len(req.TLS.PeerCertificates) != 1 {
+			return gateway.InterceptorActionForward, "", nil
+		}
+
+		cert := req.TLS.PeerCertificates[0]
+
+		block, err := tglib.CertToPEM(cert)
+		if err != nil {
+			return gateway.InterceptorActionStop, "", err
+		}
+
+		enc, err := elemental.NewAESAttributeEncrypter(encryptionPassphrase)
+		if err != nil {
+			return gateway.InterceptorActionStop, "", err
+		}
+
+		h, err := enc.EncryptString(
+			strings.ReplaceAll(
+				string(pem.EncodeToMemory(block)),
+				"\n",
+				" ",
+			),
+		)
+		if err != nil {
+			return gateway.InterceptorActionStop, "", err
+		}
+
+		req.Header.Set("X-TLS-Certificate", h)
+
+		return gateway.InterceptorActionForward, "", nil
+	}
+}

--- a/pkgs/gwutils/gwutils.go
+++ b/pkgs/gwutils/gwutils.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/karlseguin/ccache/v2"
 	"go.aporeto.io/a3s/pkgs/api"
-	"go.aporeto.io/a3s/pkgs/token"
 	"go.aporeto.io/bahamut/gateway"
 	"go.aporeto.io/elemental"
 	"go.aporeto.io/manipulate"
@@ -56,7 +55,7 @@ func MakeTLSVerifyPeerCertificate(
 			return fmt.Errorf("tls: failed to parse certificate from server: %w", err)
 		}
 
-		authorityKeyId := token.Fingerprint(cert)
+		authorityKeyId := fmt.Sprintf("%02X", cert.AuthorityKeyId)
 		item := cache.Get(authorityKeyId)
 		var pool *x509.CertPool
 

--- a/pkgs/gwutils/gwutils.go
+++ b/pkgs/gwutils/gwutils.go
@@ -120,9 +120,7 @@ func MakeTLSVerifyPeerCertificate(
 // certificate verifier with MakeTLSVerifyPeerCertificate in the gateway's
 // server TLS config. A3S will blindly trust the certificate in the header,
 // which is why you MUST verify it before.
-func MakeTLSPeerCertificateForwarder(
-	encryptionPassphrase string,
-) gateway.InterceptorFunc {
+func MakeTLSPeerCertificateForwarder(encryptionPassphrase string) gateway.InterceptorFunc {
 
 	return func(
 		w http.ResponseWriter,
@@ -131,7 +129,7 @@ func MakeTLSPeerCertificateForwarder(
 		corsInjector func(),
 	) (gateway.InterceptorAction, string, error) {
 
-		if len(req.TLS.PeerCertificates) != 1 {
+		if len(req.TLS.PeerCertificates) == 0 {
 			return gateway.InterceptorActionForward, "", nil
 		}
 

--- a/pkgs/gwutils/gwutils.go
+++ b/pkgs/gwutils/gwutils.go
@@ -16,7 +16,7 @@ import (
 	"go.aporeto.io/tg/tglib"
 )
 
-// MakeTLSVerifyPeerCertificate returns a function you can use as
+// MakeTLSPeerCertificateVerifier returns a function you can use as
 // tls.Config.VerifyPeerCertificate. You will need to do this if you want to
 // support user authentication through MTLS while you are behind a
 // bahamut.Gateway.
@@ -32,7 +32,7 @@ import (
 //
 // The results are cached for the provided cacheDuration and a maximum of
 // cacheSize items will be kept.
-func MakeTLSVerifyPeerCertificate(
+func MakeTLSPeerCertificateVerifier(
 	ctx context.Context,
 	m manipulate.Manipulator,
 	opts ...VerifierOption,
@@ -123,7 +123,7 @@ func MakeTLSVerifyPeerCertificate(
 // A3S-192 or AES-256.
 //
 // WARNING: You MUST NOT use this function without installing a custom peer
-// certificate verifier with MakeTLSVerifyPeerCertificate in the gateway's
+// certificate verifier with MakeTLSPeerCertificateVerifier in the gateway's
 // server TLS config. A3S will blindly trust the certificate in the header,
 // which is why you MUST verify it before.
 func MakeTLSPeerCertificateForwarder(encryptionPassphrase string) gateway.InterceptorFunc {

--- a/pkgs/gwutils/gwutils_test.go
+++ b/pkgs/gwutils/gwutils_test.go
@@ -1,6 +1,7 @@
 package gwutils
 
 import (
+	"context"
 	"crypto"
 	"crypto/tls"
 	"crypto/x509"
@@ -51,7 +52,13 @@ func TestMakeTLSVerifyPeerCertificate(t *testing.T) {
 
 		m := maniptest.NewTestManipulator()
 
-		verifier := MakeTLSVerifyPeerCertificate(m, 10, time.Second)
+		verifier := MakeTLSVerifyPeerCertificate(
+			context.Background(),
+			m,
+			OptionTimeout(time.Second),
+			OptionCacheSize(10),
+			OptionCacheDuration(time.Second),
+		)
 
 		Convey("When no cert are passed, nothing should happen", func() {
 			err := verifier(nil, nil)

--- a/pkgs/gwutils/gwutils_test.go
+++ b/pkgs/gwutils/gwutils_test.go
@@ -41,7 +41,7 @@ func getECCert() (*x509.Certificate, crypto.PrivateKey) {
 	return cert, key
 }
 
-func TestMakeTLSVerifyPeerCertificate(t *testing.T) {
+func TestMakeTLSPeerCertificateVerifier(t *testing.T) {
 
 	Convey("Given a cert and a manipulator", t, func() {
 
@@ -52,7 +52,7 @@ func TestMakeTLSVerifyPeerCertificate(t *testing.T) {
 
 		m := maniptest.NewTestManipulator()
 
-		verifier := MakeTLSVerifyPeerCertificate(
+		verifier := MakeTLSPeerCertificateVerifier(
 			context.Background(),
 			m,
 			OptionTimeout(time.Second),

--- a/pkgs/gwutils/gwutils_test.go
+++ b/pkgs/gwutils/gwutils_test.go
@@ -1,0 +1,149 @@
+package gwutils
+
+import (
+	"crypto"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/a3s/pkgs/api"
+	"go.aporeto.io/elemental"
+	"go.aporeto.io/manipulate"
+	"go.aporeto.io/manipulate/maniptest"
+	"go.aporeto.io/tg/tglib"
+)
+
+func getECCert() (*x509.Certificate, crypto.PrivateKey) {
+
+	certBlock, keyBlock, err := tglib.Issue(pkix.Name{})
+	if err != nil {
+		panic(err)
+	}
+
+	cert, err := tglib.ParseCertificate(pem.EncodeToMemory(certBlock))
+	if err != nil {
+		panic(err)
+	}
+
+	key, err := tglib.PEMToKey(keyBlock)
+	if err != nil {
+		panic(err)
+	}
+
+	return cert, key
+}
+
+func TestMakeTLSVerifyPeerCertificate(t *testing.T) {
+
+	Convey("Given a cert and a manipulator", t, func() {
+
+		cert, _ := getECCert()
+		block, _ := tglib.CertToPEM(cert)
+		wrongCert, _ := getECCert()
+		wrongBlock, _ := tglib.CertToPEM(wrongCert)
+
+		m := maniptest.NewTestManipulator()
+
+		verifier := MakeTLSVerifyPeerCertificate(m, 10, time.Second)
+
+		Convey("When no cert are passed, nothing should happen", func() {
+			err := verifier(nil, nil)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("When given certs are garbage, it should fail", func() {
+			err := verifier([][]byte{[]byte("garbage")}, nil)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "tls: failed to parse certificate from server: x509: malformed certificate")
+		})
+
+		Convey("When the manipulator returns an error", func() {
+
+			m.MockRetrieveMany(t, func(mctx manipulate.Context, dest elemental.Identifiables) error {
+				return fmt.Errorf("boom")
+			})
+
+			err := verifier([][]byte{block.Bytes}, nil)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "unable to retrieve mtlssources: boom")
+		})
+
+		Convey("Calling with a certificate that matches an exising mtls source should work", func() {
+
+			called := 0
+			m.MockRetrieveMany(t, func(mctx manipulate.Context, dest elemental.Identifiables) error {
+				called++
+				*dest.(*api.MTLSSourcesList) = append(
+					*dest.(*api.MTLSSourcesList),
+					&api.MTLSSource{
+						CA: string(pem.EncodeToMemory(block)),
+					},
+				)
+				return nil
+			})
+
+			err := verifier([][]byte{block.Bytes}, nil)
+			So(err, ShouldBeNil)
+			So(called, ShouldEqual, 1)
+
+			Convey("When I call it again, it should work from the cache", func() {
+				err := verifier([][]byte{block.Bytes}, nil)
+				So(err, ShouldBeNil)
+				So(called, ShouldEqual, 1)
+			})
+		})
+
+		Convey("Calling with a certificate that matches an exising mtls with a wrong cert should fail", func() {
+
+			m.MockRetrieveMany(t, func(mctx manipulate.Context, dest elemental.Identifiables) error {
+				*dest.(*api.MTLSSourcesList) = append(
+					*dest.(*api.MTLSSourcesList),
+					&api.MTLSSource{
+						CA: string(pem.EncodeToMemory(wrongBlock)),
+					},
+				)
+				return nil
+			})
+
+			err := verifier([][]byte{block.Bytes}, nil)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldStartWith, "unable to validate client certificate: x509: certificate signed by unknown authority")
+		})
+
+		Convey("Calling with a certificate that does not matche any exising mtls source should fail", func() {
+
+			m.MockRetrieveMany(t, func(mctx manipulate.Context, dest elemental.Identifiables) error {
+				return nil
+			})
+
+			err := verifier([][]byte{block.Bytes}, nil)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "unable to retrieve any matching mtlssource")
+		})
+
+		Convey("When more than one source match, it should fail", func() {
+
+			m.MockRetrieveMany(t, func(mctx manipulate.Context, dest elemental.Identifiables) error {
+
+				*dest.(*api.MTLSSourcesList) = append(
+					*dest.(*api.MTLSSourcesList),
+					&api.MTLSSource{
+						CA: string(pem.EncodeToMemory(block)),
+					},
+					&api.MTLSSource{
+						CA: string(pem.EncodeToMemory(block)),
+					},
+				)
+				return nil
+			})
+
+			err := verifier([][]byte{block.Bytes}, nil)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "more than one mtls sources hold the signing CA. this is not supported")
+		})
+	})
+}

--- a/pkgs/gwutils/gwutils_test.go
+++ b/pkgs/gwutils/gwutils_test.go
@@ -82,7 +82,7 @@ func TestMakeTLSPeerCertificateVerifier(t *testing.T) {
 			So(err.Error(), ShouldEqual, "unable to retrieve mtlssources: boom")
 		})
 
-		Convey("Calling with a certificate that matches an exising mtls source should work", func() {
+		Convey("Calling with a certificate that matches an existing mtls source should work", func() {
 
 			called := 0
 			m.MockRetrieveMany(t, func(mctx manipulate.Context, dest elemental.Identifiables) error {
@@ -107,7 +107,7 @@ func TestMakeTLSPeerCertificateVerifier(t *testing.T) {
 			})
 		})
 
-		Convey("Calling with a certificate that matches an exising mtls with a wrong cert should fail", func() {
+		Convey("Calling with a certificate that matches an existing mtls with a wrong cert should fail", func() {
 
 			m.MockRetrieveMany(t, func(mctx manipulate.Context, dest elemental.Identifiables) error {
 				*dest.(*api.MTLSSourcesList) = append(
@@ -124,7 +124,7 @@ func TestMakeTLSPeerCertificateVerifier(t *testing.T) {
 			So(err.Error(), ShouldStartWith, "unable to validate client certificate: x509: certificate signed by unknown authority")
 		})
 
-		Convey("Calling with a certificate that does not matche any exising mtls source should fail", func() {
+		Convey("Calling with a certificate that does not matche any existing mtls source should fail", func() {
 
 			m.MockRetrieveMany(t, func(mctx manipulate.Context, dest elemental.Identifiables) error {
 				return nil

--- a/pkgs/gwutils/options.go
+++ b/pkgs/gwutils/options.go
@@ -5,7 +5,7 @@ import (
 )
 
 // VerifierOption can be used to configure
-// optional aspect of MAkeTLSVerifyPeerCertificate
+// optional aspect of MakeTLSPeerCertificateVerifier.
 type VerifierOption func(*verifierConf)
 
 type verifierConf struct {

--- a/pkgs/gwutils/options.go
+++ b/pkgs/gwutils/options.go
@@ -18,6 +18,7 @@ func newVerifierConf() verifierConf {
 	return verifierConf{
 		cacheMaxSize:  2048,
 		cacheDuration: 10 * time.Minute,
+		timeout:       10 * time.Second,
 	}
 }
 

--- a/pkgs/gwutils/options.go
+++ b/pkgs/gwutils/options.go
@@ -1,0 +1,45 @@
+package gwutils
+
+import (
+	"time"
+)
+
+// VerifierOption can be used to configure
+// optional aspect of MAkeTLSVerifyPeerCertificate
+type VerifierOption func(*verifierConf)
+
+type verifierConf struct {
+	cacheDuration time.Duration
+	cacheMaxSize  int64
+	timeout       time.Duration
+}
+
+func newVerifierConf() verifierConf {
+	return verifierConf{
+		cacheMaxSize:  2048,
+		cacheDuration: 10 * time.Minute,
+	}
+}
+
+// OptionCacheDuration sets the life time of cached CAs.
+func OptionCacheDuration(d time.Duration) VerifierOption {
+	return func(cfg *verifierConf) {
+		cfg.cacheDuration = d
+	}
+}
+
+// OptionCacheSize sets the maximum number of items
+// that can be in the cache, before evicting older ones.
+func OptionCacheSize(s int64) VerifierOption {
+	return func(cfg *verifierConf) {
+		cfg.cacheMaxSize = s
+	}
+}
+
+// OptionTimeout sets the maximum amount of time to
+// wait for A3S to reply.
+func OptionTimeout(d time.Duration) VerifierOption {
+	return func(cfg *verifierConf) {
+		cfg.timeout = d
+	}
+}

--- a/pkgs/gwutils/options_test.go
+++ b/pkgs/gwutils/options_test.go
@@ -1,0 +1,29 @@
+package gwutils
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestOptions(t *testing.T) {
+
+	Convey("OptionCacheDuration should work", t, func() {
+		cfg := newVerifierConf()
+		OptionCacheDuration(time.Second)(&cfg)
+		So(cfg.cacheDuration, ShouldEqual, time.Second)
+	})
+
+	Convey("OptionCacheSize should work", t, func() {
+		cfg := newVerifierConf()
+		OptionCacheSize(42)(&cfg)
+		So(cfg.cacheMaxSize, ShouldEqual, 42)
+	})
+
+	Convey("OptionTimeout should work", t, func() {
+		cfg := newVerifierConf()
+		OptionTimeout(time.Second)(&cfg)
+		So(cfg.timeout, ShouldEqual, time.Second)
+	})
+}


### PR DESCRIPTION
This patch provides two functions to help supporting MTLS authentication when behind a bahamut.Gateway.