### PR TITLE
new/dev: added development openldap server

### DIFF
--- a/dev/ldap/README.md
+++ b/dev/ldap/README.md
@@ -1,0 +1,35 @@
+# a3s dev ldap
+
+This folder contains a ready to use pre-configured ldap server and an import
+file to declare it as a source in A3S.
+
+> Note: This entire setup is insecure. This is intended for development
+> purposes.
+
+## Start the container
+
+	docker compose up
+
+The server listens on port 11389, with no TLS.
+
+* admin username: `cn=admin,dc=universe,dc=io`
+* admin password: `password`
+
+It contains 2 additional pre-populated users:
+
+- username: `okenobi` password: `pass`
+- username: `dvader` password: `pass`
+
+## Import the ldap source
+
+To use the ldap server as an A3S ldap source, import its declaration with the
+following command:
+
+	a3sctl api create import \
+		--input-file ./a3s-ldapsource.yaml \
+		--namespace /
+
+> Note: There will be a helper subcommand to handle imports soon. The version
+> above uses the raw API. Check apoctl --help.
+
+The source name is `a3s-dev-ldap`.

--- a/dev/ldap/a3s-ldapsource.yaml
+++ b/dev/ldap/a3s-ldapsource.yaml
@@ -1,0 +1,8 @@
+label: a3s:dev:ldap
+LDAPSources:
+- name: a3s-dev-ldap
+  address: 127.0.0.1:11389
+  baseDN: dc=universe,dc=io
+  bindDN: cn=admin,dc=universe,dc=io
+  bindPassword: "password"
+  securityProtocol: None

--- a/dev/ldap/docker-compose.yaml
+++ b/dev/ldap/docker-compose.yaml
@@ -1,0 +1,11 @@
+services:
+  ldap:
+    image: bitnami/openldap
+    ports:
+      - "11389:1389"
+    hostname: ldap
+    environment:
+      LDAP_ADMIN_PASSWORD: password
+      LDAP_ROOT: dc=universe,dc=io
+      LDAP_USERS: okenobi,dvader
+      LDAP_PASSWORDS: pass,pass

--- a/internal/issuer/ldapissuer/ldap.go
+++ b/internal/issuer/ldapissuer/ldap.go
@@ -103,10 +103,14 @@ func (c *ldapIssuer) retrieveEntry(username string, password string) (*ldap.Entr
 		if err != nil {
 			return nil, nil, ErrLDAP{Err: fmt.Errorf("cannot dial: %w", err)}
 		}
+	}
+
+	if c.source.SecurityProtocol == api.LDAPSourceSecurityProtocolInbandTLS {
 		if err = conn.StartTLS(tlsConfig); err != nil {
 			return nil, nil, ErrLDAP{Err: fmt.Errorf("cannot start tls: %w", err)}
 		}
 	}
+
 	defer conn.Close()
 
 	if err = conn.Bind(c.source.BindDN, c.source.BindPassword); err != nil {

--- a/internal/issuer/ldapissuer/ldap_test.go
+++ b/internal/issuer/ldapissuer/ldap_test.go
@@ -40,6 +40,7 @@ func TestFromCredential(t *testing.T) {
 		src := api.NewLDAPSource()
 		src.Namespace = "/my/ns"
 		src.Name = "my-src"
+		src.SecurityProtocol = api.LDAPSourceSecurityProtocolInbandTLS
 		iss := newLDAPIssuer(src)
 		err := iss.fromCredentials(context.Background(), "", "")
 		So(err, ShouldNotBeNil)
@@ -51,6 +52,7 @@ func TestFromCredential(t *testing.T) {
 		src.Namespace = "/my/ns"
 		src.Name = "my-src"
 		src.CA = "a-ca"
+		src.SecurityProtocol = api.LDAPSourceSecurityProtocolInbandTLS
 		iss := newLDAPIssuer(src)
 		err := iss.fromCredentials(context.Background(), "", "")
 		So(err, ShouldNotBeNil)

--- a/pkgs/api/doc/documentation.md
+++ b/pkgs/api/doc/documentation.md
@@ -815,7 +815,7 @@ CCqGSM49BAMCA0gAMEUCIQD+nL9RF9EvQXHyYuJ31Lz9yWd9hsK91stnpAs890gS
   "bindPassword": "s3cr3t",
   "bindSearchFilter": "uid={USERNAME}",
   "name": "mypki",
-  "securityProtocol": "InbandTLS"
+  "securityProtocol": "TLS"
 }
 ```
 
@@ -953,14 +953,14 @@ The namespace of the object.
 
 ##### `securityProtocol`
 
-Type: `enum(TLS | InbandTLS)`
+Type: `enum(TLS | InbandTLS | None)`
 
 Specifies the connection type for the LDAP provider.
 
 Default value:
 
 ```json
-"InbandTLS"
+"TLS"
 ```
 
 ### MTLSSource

--- a/pkgs/api/ldapsource.go
+++ b/pkgs/api/ldapsource.go
@@ -15,6 +15,9 @@ const (
 	// LDAPSourceSecurityProtocolInbandTLS represents the value InbandTLS.
 	LDAPSourceSecurityProtocolInbandTLS LDAPSourceSecurityProtocolValue = "InbandTLS"
 
+	// LDAPSourceSecurityProtocolNone represents the value None.
+	LDAPSourceSecurityProtocolNone LDAPSourceSecurityProtocolValue = "None"
+
 	// LDAPSourceSecurityProtocolTLS represents the value TLS.
 	LDAPSourceSecurityProtocolTLS LDAPSourceSecurityProtocolValue = "TLS"
 )
@@ -164,7 +167,7 @@ func NewLDAPSource() *LDAPSource {
 		BindSearchFilter: "uid={USERNAME}",
 		IgnoredKeys:      []string{},
 		IncludedKeys:     []string{},
-		SecurityProtocol: LDAPSourceSecurityProtocolInbandTLS,
+		SecurityProtocol: LDAPSourceSecurityProtocolTLS,
 	}
 }
 
@@ -565,7 +568,7 @@ func (o *LDAPSource) Validate() error {
 		requiredErrors = requiredErrors.Append(err)
 	}
 
-	if err := elemental.ValidateStringInList("securityProtocol", string(o.SecurityProtocol), []string{"TLS", "InbandTLS"}, false); err != nil {
+	if err := elemental.ValidateStringInList("securityProtocol", string(o.SecurityProtocol), []string{"TLS", "InbandTLS", "None"}, false); err != nil {
 		errors = errors.Append(err)
 	}
 
@@ -836,10 +839,10 @@ the claims that are about to be delivered using this authentication source.`,
 		Type:           "string",
 	},
 	"SecurityProtocol": {
-		AllowedChoices: []string{"TLS", "InbandTLS"},
+		AllowedChoices: []string{"TLS", "InbandTLS", "None"},
 		BSONFieldName:  "securityprotocol",
 		ConvertedName:  "SecurityProtocol",
-		DefaultValue:   LDAPSourceSecurityProtocolInbandTLS,
+		DefaultValue:   LDAPSourceSecurityProtocolTLS,
 		Description:    `Specifies the connection type for the LDAP provider.`,
 		Exposed:        true,
 		Name:           "securityProtocol",
@@ -1067,10 +1070,10 @@ the claims that are about to be delivered using this authentication source.`,
 		Type:           "string",
 	},
 	"securityprotocol": {
-		AllowedChoices: []string{"TLS", "InbandTLS"},
+		AllowedChoices: []string{"TLS", "InbandTLS", "None"},
 		BSONFieldName:  "securityprotocol",
 		ConvertedName:  "SecurityProtocol",
-		DefaultValue:   LDAPSourceSecurityProtocolInbandTLS,
+		DefaultValue:   LDAPSourceSecurityProtocolTLS,
 		Description:    `Specifies the connection type for the LDAP provider.`,
 		Exposed:        true,
 		Name:           "securityProtocol",

--- a/pkgs/api/openapi3/toplevel
+++ b/pkgs/api/openapi3/toplevel
@@ -730,11 +730,12 @@
             "type": "string"
           },
           "securityProtocol": {
-            "default": "InbandTLS",
+            "default": "TLS",
             "description": "Specifies the connection type for the LDAP provider.",
             "enum": [
               "TLS",
-              "InbandTLS"
+              "InbandTLS",
+              "None"
             ]
           }
         },

--- a/pkgs/api/specs/ldapsource.spec
+++ b/pkgs/api/specs/ldapsource.spec
@@ -146,4 +146,5 @@ attributes:
     allowed_choices:
     - TLS
     - InbandTLS
-    default_value: InbandTLS
+    - None
+    default_value: TLS

--- a/pkgs/importing/hash_test.go
+++ b/pkgs/importing/hash_test.go
@@ -205,7 +205,7 @@ func Test_sanitize(t *testing.T) {
 				obj.ImportHash = "should be removed"
 				obj.ImportLabel = "should be removed"
 				obj.Namespace = "should be removed because it's autogen"
-				obj.SecurityProtocol = api.LDAPSourceSecurityProtocolInbandTLS
+				obj.SecurityProtocol = api.LDAPSourceSecurityProtocolTLS
 				return args{
 					obj,
 					api.Manager(),
@@ -227,7 +227,7 @@ func Test_sanitize(t *testing.T) {
 				obj.ImportHash = "should be removed"
 				obj.ImportLabel = "should be removed"
 				obj.Namespace = "should be removed because it's autogen"
-				obj.SecurityProtocol = api.LDAPSourceSecurityProtocolTLS
+				obj.SecurityProtocol = api.LDAPSourceSecurityProtocolInbandTLS
 				return args{
 					obj,
 					api.Manager(),
@@ -236,7 +236,7 @@ func Test_sanitize(t *testing.T) {
 			map[string]interface{}{
 				"name":             "name",
 				"CA":               "ca",
-				"securityProtocol": api.LDAPSourceSecurityProtocolTLS,
+				"securityProtocol": api.LDAPSourceSecurityProtocolInbandTLS,
 			},
 			false,
 			nil,


### PR DESCRIPTION
This patch adds a docker-compose and an a3s import file to easily be able to test ldapsources.