### PR TITLE
fixed/issue: do not automatically cap validity. return errors instead

### DIFF
--- a/internal/issuer/a3sissuer/a3s.go
+++ b/internal/issuer/a3sissuer/a3s.go
@@ -102,7 +102,7 @@ func computeNewValidity(originalExpUNIX *jwt.NumericDate, requestedValidity time
 
 	originalExp := originalExpUNIX.Local()
 	if now.Add(requestedValidity).After(originalExp) && !isRefresh {
-		return jwt.NewNumericDate(originalExp), nil
+		return nil, fmt.Errorf("the request validity is greater than the original non refresh token")
 	}
 
 	return jwt.NewNumericDate(now.Add(requestedValidity)), nil

--- a/internal/issuer/a3sissuer/a3s_test.go
+++ b/internal/issuer/a3sissuer/a3s_test.go
@@ -199,17 +199,17 @@ func Test_computeNewValidity(t *testing.T) {
 				48 * time.Hour,
 				false,
 			},
-			exp,
-			false,
+			nil,
+			true,
 		},
 		{
-			"requested the same",
+			"requested roughly the same",
 			args{
 				exp,
-				time.Until(exp.Local()),
+				time.Until(exp.Local()) - time.Millisecond,
 				false,
 			},
-			exp,
+			jwt.NewNumericDate(exp.Add(-time.Millisecond)),
 			false,
 		},
 		{

--- a/internal/processors/issue.go
+++ b/internal/processors/issue.go
@@ -78,7 +78,16 @@ func (p *IssueProcessor) ProcessCreate(bctx bahamut.Context) (err error) {
 
 	validity, _ := time.ParseDuration(req.Validity) // elemental already validated this
 	if validity > p.maxValidity {
-		validity = p.maxValidity
+		return elemental.NewError(
+			"Invalid validity",
+			fmt.Sprintf(
+				"The requested validity '%s' is greater than the maximum allowed ('%s')",
+				req.Validity,
+				p.maxValidity,
+			),
+			"a3s:authn",
+			http.StatusBadRequest,
+		)
 	}
 	exp := time.Now().Add(validity)
 

--- a/internal/processors/issue.go
+++ b/internal/processors/issue.go
@@ -89,6 +89,11 @@ func (p *IssueProcessor) ProcessCreate(bctx bahamut.Context) (err error) {
 			http.StatusBadRequest,
 		)
 	}
+
+	if validity == 0 {
+		validity = p.maxValidity
+	}
+
 	exp := time.Now().Add(validity)
 
 	audience := req.Audience
@@ -133,6 +138,9 @@ func (p *IssueProcessor) ProcessCreate(bctx bahamut.Context) (err error) {
 		}
 
 	case api.IssueSourceTypeA3S:
+		if req.Validity == "" {
+			validity = 0
+		}
 		issuer, err = p.handleTokenIssue(bctx.Context(), req, validity, audience)
 		// we reset to 0 to skip setting exp during issuing of the token
 		// as the token issers already caps it.

--- a/pkgs/api/doc/documentation.md
+++ b/pkgs/api/doc/documentation.md
@@ -34,8 +34,7 @@ Issues a new a normalized token using various authentication sources.
   "sourceName": "/my/ns",
   "sourceNamespace": "/my/ns",
   "sourceType": "OIDC",
-  "tokenType": "Identity",
-  "validity": "24h"
+  "tokenType": "Identity"
 }
 ```
 
@@ -214,12 +213,6 @@ Type: `string`
 Configures the maximum length of validity for a token, using
 [Golang duration syntax](https://golang.org/pkg/time/#example_Duration). If it
 is bigger than the configured max validity, it will be capped. Default: `24h`.
-
-Default value:
-
-```json
-"24h"
-```
 
 ### IssueA3S
 

--- a/pkgs/api/issue.go
+++ b/pkgs/api/issue.go
@@ -236,7 +236,6 @@ func NewIssue() *Issue {
 		RestrictedPermissions: []string{},
 		Cloak:                 []string{},
 		TokenType:             IssueTokenTypeIdentity,
-		Validity:              "24h",
 	}
 }
 
@@ -887,7 +886,6 @@ credentials from internal or external source of authentication.`,
 	"Validity": {
 		AllowedChoices: []string{},
 		ConvertedName:  "Validity",
-		DefaultValue:   "24h",
 		Description: `Configures the maximum length of validity for a token, using
 [Golang duration syntax](https://golang.org/pkg/time/#example_Duration). If it
 is bigger than the configured max validity, it will be capped. Default: ` + "`" + `24h` + "`" + `.`,
@@ -1115,7 +1113,6 @@ credentials from internal or external source of authentication.`,
 	"validity": {
 		AllowedChoices: []string{},
 		ConvertedName:  "Validity",
-		DefaultValue:   "24h",
 		Description: `Configures the maximum length of validity for a token, using
 [Golang duration syntax](https://golang.org/pkg/time/#example_Duration). If it
 is bigger than the configured max validity, it will be capped. Default: ` + "`" + `24h` + "`" + `.`,

--- a/pkgs/api/openapi3/toplevel
+++ b/pkgs/api/openapi3/toplevel
@@ -479,7 +479,6 @@
             ]
           },
           "validity": {
-            "default": "24h",
             "description": "Configures the maximum length of validity for a token, using\n[Golang duration syntax](https://golang.org/pkg/time/#example_Duration). If it\nis bigger than the configured max validity, it will be capped. Default: `24h`.",
             "type": "string"
           }

--- a/pkgs/api/specs/issue.spec
+++ b/pkgs/api/specs/issue.spec
@@ -249,7 +249,6 @@ attributes:
       is bigger than the configured max validity, it will be capped. Default: `24h`.
     type: string
     exposed: true
-    default_value: 24h
     omit_empty: true
     validations:
     - $duration


### PR DESCRIPTION
This patches remove validity auto-capping that could end up being confusing. Return errors instead