### PR TITLE
new/token: add system claim @issuer

### DIFF
--- a/pkgs/token/token.go
+++ b/pkgs/token/token.go
@@ -144,6 +144,8 @@ func (t *IdentityToken) JWT(key crypto.PrivateKey, kid string, issuer string, au
 		t.Identity = append(t.Identity, fmt.Sprintf("@source:name=%s", t.Source.Name))
 	}
 
+	t.Identity = append(t.Identity, fmt.Sprintf("@issuer=%s", t.Issuer))
+
 	j := jwt.NewWithClaims(jwt.SigningMethodES256, t)
 
 	if kid != "" {

--- a/pkgs/token/token_test.go
+++ b/pkgs/token/token_test.go
@@ -95,6 +95,7 @@ func TestParse(t *testing.T) {
 			token3, err := Parse(token2, keychain, "iss", "aud")
 			So(err, ShouldBeNil)
 			So(token3.Identity, ShouldResemble, []string{
+				"@issuer=iss",
 				"@source:name=mysource",
 				"@source:namespace=/my/ns",
 				"@source:type=certificate",
@@ -113,6 +114,7 @@ func TestParse(t *testing.T) {
 			So(token2.ExpiresAt, ShouldResemble, token1.ExpiresAt)
 			So(token2.IssuedAt, ShouldResemble, token1.IssuedAt)
 			So(token2.Identity, ShouldResemble, []string{
+				"@issuer=iss",
 				"@source:name=mysource",
 				"@source:namespace=/my/ns",
 				"@source:type=certificate",


### PR DESCRIPTION
This patch makes all token have the @issuer={issuer} as part of the
identity claims. This is preliminary work to support trusting tokens
issued from other instances of A3S as-is.
