### PR TITLE
refactor: token printing

### DIFF
--- a/cmd/a3sctl/internal/authcmd/a3s.go
+++ b/cmd/a3sctl/internal/authcmd/a3s.go
@@ -2,11 +2,13 @@ package authcmd
 
 import (
 	"context"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.aporeto.io/a3s/pkgs/authlib"
 	"go.aporeto.io/a3s/pkgs/permissions"
+	"go.aporeto.io/a3s/pkgs/token"
 	"go.aporeto.io/manipulate/manipcli"
 )
 
@@ -22,6 +24,7 @@ func makeA3SCmd(mmaker manipcli.ManipulatorMaker, restrictions *permissions.Rest
 			fAudience := viper.GetStringSlice("audience")
 			fCloak := viper.GetStringSlice("cloak")
 			fQRCode := viper.GetBool("qrcode")
+			fCheck := viper.GetBool("check")
 			fValidity := viper.GetDuration("validity")
 			fRefresh := viper.GetBool("refresh")
 
@@ -48,9 +51,13 @@ func makeA3SCmd(mmaker manipcli.ManipulatorMaker, restrictions *permissions.Rest
 				return err
 			}
 
-			printToken(t, fQRCode)
-
-			return nil
+			return token.Fprint(
+				os.Stdout,
+				t,
+				token.PrintOptionDecoded(fCheck),
+				token.PrintOptionQRCode(fQRCode),
+				token.PrintOptionRaw(true),
+			)
 		},
 	}
 

--- a/cmd/a3sctl/internal/authcmd/auth.go
+++ b/cmd/a3sctl/internal/authcmd/auth.go
@@ -1,10 +1,6 @@
 package authcmd
 
 import (
-	"fmt"
-	"os"
-
-	"github.com/mdp/qrterminal"
 	"github.com/spf13/cobra"
 	"go.aporeto.io/a3s/cmd/a3sctl/internal/help"
 	"go.aporeto.io/a3s/pkgs/permissions"
@@ -25,6 +21,7 @@ func New(mmaker manipcli.ManipulatorMaker) *cobra.Command {
 	cmd.PersistentFlags().StringSlice("audience", nil, "Requested audience for the token.")
 	cmd.PersistentFlags().StringSlice("cloak", nil, "Cloak identity claims. Only claims with a prefix matching of of the given string will be used in the token.")
 	cmd.PersistentFlags().Bool("qrcode", false, "If passed, display the token as a QR code.")
+	cmd.PersistentFlags().Bool("check", false, "If passed, display the decoded token")
 	cmd.PersistentFlags().Bool("refresh", false, "If set, ask for a refresh token.")
 
 	// Freaking pglags and its non configurable split char
@@ -50,26 +47,4 @@ func New(mmaker manipcli.ManipulatorMaker) *cobra.Command {
 	)
 
 	return cmd
-}
-
-func printToken(token string, qrCode bool) {
-
-	if !qrCode {
-		fmt.Println(token)
-		return
-	}
-
-	qrterminal.GenerateWithConfig(
-		token,
-		qrterminal.Config{
-			Writer:         os.Stdout,
-			Level:          qrterminal.M,
-			HalfBlocks:     true,
-			QuietZone:      1,
-			BlackChar:      qrterminal.BLACK_BLACK,
-			WhiteBlackChar: qrterminal.WHITE_BLACK,
-			WhiteChar:      qrterminal.WHITE_WHITE,
-			BlackWhiteChar: qrterminal.BLACK_WHITE,
-		},
-	)
 }

--- a/cmd/a3sctl/internal/authcmd/auto.go
+++ b/cmd/a3sctl/internal/authcmd/auto.go
@@ -42,13 +42,20 @@ func makeAutoCmd(mmaker manipcli.ManipulatorMaker) *cobra.Command {
 			}
 
 			fCheck := viper.GetBool("check")
-			if !fCheck {
+			fQRCode := viper.GetBool("qrcode")
+			if !fCheck && !fQRCode {
 				return nil
 			}
 
 			fToken := viper.GetString("token")
-			fQRCode := viper.GetBool("qrcode")
-			return DisplayToken(fToken, true, fQRCode)
+
+			return token.Fprint(
+				os.Stdout,
+				fToken,
+				token.PrintOptionDecoded(fCheck),
+				token.PrintOptionQRCode(fQRCode),
+				token.PrintOptionRaw(true),
+			)
 		},
 	}
 

--- a/cmd/a3sctl/internal/authcmd/aws.go
+++ b/cmd/a3sctl/internal/authcmd/aws.go
@@ -2,11 +2,13 @@ package authcmd
 
 import (
 	"context"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.aporeto.io/a3s/pkgs/authlib"
 	"go.aporeto.io/a3s/pkgs/permissions"
+	"go.aporeto.io/a3s/pkgs/token"
 	"go.aporeto.io/manipulate/manipcli"
 )
 
@@ -24,6 +26,7 @@ func makeAWSCmd(mmaker manipcli.ManipulatorMaker, restrictions *permissions.Rest
 			fAudience := viper.GetStringSlice("audience")
 			fCloak := viper.GetStringSlice("cloak")
 			fQRCode := viper.GetBool("qrcode")
+			fCheck := viper.GetBool("check")
 			fValidity := viper.GetDuration("validity")
 			fRefresh := viper.GetBool("refresh")
 
@@ -48,9 +51,13 @@ func makeAWSCmd(mmaker manipcli.ManipulatorMaker, restrictions *permissions.Rest
 				return err
 			}
 
-			printToken(t, fQRCode)
-
-			return nil
+			return token.Fprint(
+				os.Stdout,
+				t,
+				token.PrintOptionDecoded(fCheck),
+				token.PrintOptionQRCode(fQRCode),
+				token.PrintOptionRaw(true),
+			)
 		},
 	}
 

--- a/cmd/a3sctl/internal/authcmd/azure.go
+++ b/cmd/a3sctl/internal/authcmd/azure.go
@@ -2,11 +2,13 @@ package authcmd
 
 import (
 	"context"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.aporeto.io/a3s/pkgs/authlib"
 	"go.aporeto.io/a3s/pkgs/permissions"
+	"go.aporeto.io/a3s/pkgs/token"
 	"go.aporeto.io/manipulate/manipcli"
 )
 
@@ -22,6 +24,7 @@ func makeAzureCmd(mmaker manipcli.ManipulatorMaker, restrictions *permissions.Re
 			fAudience := viper.GetStringSlice("audience")
 			fCloak := viper.GetStringSlice("cloak")
 			fQRCode := viper.GetBool("qrcode")
+			fCheck := viper.GetBool("check")
 			fValidity := viper.GetDuration("validity")
 			fRenew := viper.GetBool("renew")
 
@@ -44,9 +47,13 @@ func makeAzureCmd(mmaker manipcli.ManipulatorMaker, restrictions *permissions.Re
 				return err
 			}
 
-			printToken(t, fQRCode)
-
-			return nil
+			return token.Fprint(
+				os.Stdout,
+				t,
+				token.PrintOptionDecoded(fCheck),
+				token.PrintOptionQRCode(fQRCode),
+				token.PrintOptionRaw(true),
+			)
 		},
 	}
 

--- a/cmd/a3sctl/internal/authcmd/gcp.go
+++ b/cmd/a3sctl/internal/authcmd/gcp.go
@@ -2,11 +2,13 @@ package authcmd
 
 import (
 	"context"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.aporeto.io/a3s/pkgs/authlib"
 	"go.aporeto.io/a3s/pkgs/permissions"
+	"go.aporeto.io/a3s/pkgs/token"
 	"go.aporeto.io/manipulate/manipcli"
 )
 
@@ -23,6 +25,7 @@ func makeGCPCmd(mmaker manipcli.ManipulatorMaker, restrictions *permissions.Rest
 			fAudience := viper.GetStringSlice("audience")
 			fCloak := viper.GetStringSlice("cloak")
 			fQRCode := viper.GetBool("qrcode")
+			fCheck := viper.GetBool("check")
 			fValidity := viper.GetDuration("validity")
 			fRefresh := viper.GetBool("refresh")
 
@@ -46,9 +49,13 @@ func makeGCPCmd(mmaker manipcli.ManipulatorMaker, restrictions *permissions.Rest
 				return err
 			}
 
-			printToken(t, fQRCode)
-
-			return nil
+			return token.Fprint(
+				os.Stdout,
+				t,
+				token.PrintOptionDecoded(fCheck),
+				token.PrintOptionQRCode(fQRCode),
+				token.PrintOptionRaw(true),
+			)
 		},
 	}
 

--- a/cmd/a3sctl/internal/authcmd/http.go
+++ b/cmd/a3sctl/internal/authcmd/http.go
@@ -2,6 +2,7 @@ package authcmd
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -9,6 +10,7 @@ import (
 	"go.aporeto.io/a3s/cmd/a3sctl/internal/helpers"
 	"go.aporeto.io/a3s/pkgs/authlib"
 	"go.aporeto.io/a3s/pkgs/permissions"
+	"go.aporeto.io/a3s/pkgs/token"
 	"go.aporeto.io/manipulate/manipcli"
 )
 
@@ -28,6 +30,7 @@ func makeHTTPCmd(mmaker manipcli.ManipulatorMaker, restrictions *permissions.Res
 			fPass := helpers.ReadFlag("password: ", "pass", true)
 			fTOTP := helpers.ReadFlag("totp: ", "totp", false)
 			fCloak := viper.GetStringSlice("cloak")
+			fCheck := viper.GetBool("check")
 			fQRCode := viper.GetBool("qrcode")
 			fValidity := viper.GetDuration("validity")
 			fRefresh := viper.GetBool("refresh")
@@ -53,9 +56,13 @@ func makeHTTPCmd(mmaker manipcli.ManipulatorMaker, restrictions *permissions.Res
 				return err
 			}
 
-			printToken(t, fQRCode)
-
-			return nil
+			return token.Fprint(
+				os.Stdout,
+				t,
+				token.PrintOptionDecoded(fCheck),
+				token.PrintOptionQRCode(fQRCode),
+				token.PrintOptionRaw(true),
+			)
 		},
 	}
 

--- a/cmd/a3sctl/internal/authcmd/ldap.go
+++ b/cmd/a3sctl/internal/authcmd/ldap.go
@@ -2,6 +2,7 @@ package authcmd
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -9,6 +10,7 @@ import (
 	"go.aporeto.io/a3s/cmd/a3sctl/internal/helpers"
 	"go.aporeto.io/a3s/pkgs/authlib"
 	"go.aporeto.io/a3s/pkgs/permissions"
+	"go.aporeto.io/a3s/pkgs/token"
 	"go.aporeto.io/manipulate/manipcli"
 )
 
@@ -28,6 +30,7 @@ func makeLDAPCmd(mmaker manipcli.ManipulatorMaker, restrictions *permissions.Res
 			fPass := helpers.ReadFlag("password: ", "pass", true)
 			fCloak := viper.GetStringSlice("cloak")
 			fQRCode := viper.GetBool("qrcode")
+			fCheck := viper.GetBool("check")
 			fValidity := viper.GetDuration("validity")
 			fRefresh := viper.GetBool("refresh")
 
@@ -51,9 +54,13 @@ func makeLDAPCmd(mmaker manipcli.ManipulatorMaker, restrictions *permissions.Res
 				return err
 			}
 
-			printToken(t, fQRCode)
-
-			return nil
+			return token.Fprint(
+				os.Stdout,
+				t,
+				token.PrintOptionDecoded(fCheck),
+				token.PrintOptionQRCode(fQRCode),
+				token.PrintOptionRaw(true),
+			)
 		},
 	}
 

--- a/cmd/a3sctl/internal/authcmd/mtls.go
+++ b/cmd/a3sctl/internal/authcmd/mtls.go
@@ -2,6 +2,7 @@ package authcmd
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -9,6 +10,7 @@ import (
 	"go.aporeto.io/a3s/cmd/a3sctl/internal/helpers"
 	"go.aporeto.io/a3s/pkgs/authlib"
 	"go.aporeto.io/a3s/pkgs/permissions"
+	"go.aporeto.io/a3s/pkgs/token"
 	"go.aporeto.io/manipulate/manipcli"
 	"go.aporeto.io/manipulate/maniphttp"
 	"go.aporeto.io/tg/tglib"
@@ -30,6 +32,7 @@ func makeMTLSCmd(mmaker manipcli.ManipulatorMaker, restrictions *permissions.Res
 			fAudience := viper.GetStringSlice("audience")
 			fCloak := viper.GetStringSlice("cloak")
 			fQRCode := viper.GetBool("qrcode")
+			fCheck := viper.GetBool("check")
 			fValidity := viper.GetDuration("validity")
 			fRefresh := viper.GetBool("refresh")
 
@@ -54,9 +57,13 @@ func makeMTLSCmd(mmaker manipcli.ManipulatorMaker, restrictions *permissions.Res
 				return err
 			}
 
-			printToken(t, fQRCode)
-
-			return nil
+			return token.Fprint(
+				os.Stdout,
+				t,
+				token.PrintOptionDecoded(fCheck),
+				token.PrintOptionQRCode(fQRCode),
+				token.PrintOptionRaw(true),
+			)
 		},
 	}
 

--- a/cmd/a3sctl/internal/authcmd/oidc.go
+++ b/cmd/a3sctl/internal/authcmd/oidc.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/viper"
 	"go.aporeto.io/a3s/pkgs/authlib"
 	"go.aporeto.io/a3s/pkgs/permissions"
+	"go.aporeto.io/a3s/pkgs/token"
 	"go.aporeto.io/manipulate/manipcli"
 	"go.uber.org/zap"
 )
@@ -32,6 +33,7 @@ func makeOIDCCmd(mmaker manipcli.ManipulatorMaker, restrictions *permissions.Res
 			fAudience := viper.GetStringSlice("audience")
 			fCloak := viper.GetStringSlice("cloak")
 			fQRCode := viper.GetBool("qrcode")
+			fCheck := viper.GetBool("check")
 			fRefresh := viper.GetBool("refresh")
 
 			if fSourceNamespace == "" {
@@ -82,9 +84,13 @@ func makeOIDCCmd(mmaker manipcli.ManipulatorMaker, restrictions *permissions.Res
 				return err
 			}
 
-			printToken(t, fQRCode)
-
-			return nil
+			return token.Fprint(
+				os.Stdout,
+				t,
+				token.PrintOptionDecoded(fCheck),
+				token.PrintOptionQRCode(fQRCode),
+				token.PrintOptionRaw(true),
+			)
 		},
 	}
 	cmd.Flags().String("source-name", "default", "The name of the auth source.")

--- a/cmd/a3sctl/internal/authcmd/remotea3s.go
+++ b/cmd/a3sctl/internal/authcmd/remotea3s.go
@@ -2,11 +2,13 @@ package authcmd
 
 import (
 	"context"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.aporeto.io/a3s/pkgs/authlib"
 	"go.aporeto.io/a3s/pkgs/permissions"
+	"go.aporeto.io/a3s/pkgs/token"
 	"go.aporeto.io/manipulate/manipcli"
 )
 
@@ -24,6 +26,7 @@ func makeRemoteA3SCmd(mmaker manipcli.ManipulatorMaker, restrictions *permission
 			fAudience := viper.GetStringSlice("audience")
 			fCloak := viper.GetStringSlice("cloak")
 			fQRCode := viper.GetBool("qrcode")
+			fCheck := viper.GetBool("check")
 			fValidity := viper.GetDuration("validity")
 			fRefresh := viper.GetBool("refresh")
 
@@ -52,9 +55,13 @@ func makeRemoteA3SCmd(mmaker manipcli.ManipulatorMaker, restrictions *permission
 				return err
 			}
 
-			printToken(t, fQRCode)
-
-			return nil
+			return token.Fprint(
+				os.Stdout,
+				t,
+				token.PrintOptionDecoded(fCheck),
+				token.PrintOptionQRCode(fQRCode),
+				token.PrintOptionRaw(true),
+			)
 		},
 	}
 

--- a/pkgs/token/print.go
+++ b/pkgs/token/print.go
@@ -1,0 +1,131 @@
+package token
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/hokaccha/go-prettyjson"
+	"github.com/mdp/qrterminal"
+)
+
+type printCfg struct {
+	raw     bool
+	decoded bool
+	qrcode  bool
+}
+
+// PrintOption represents options that can be passed to token.Print
+type PrintOption func(*printCfg)
+
+// PrintOptionRaw sets the printer to
+// print the raw token.
+func PrintOptionRaw(enabled bool) PrintOption {
+	return func(cfg *printCfg) {
+		cfg.raw = enabled
+	}
+}
+
+// PrintOptionDecoded prints the information
+// contained in the token.
+func PrintOptionDecoded(enabled bool) PrintOption {
+	return func(cfg *printCfg) {
+		cfg.decoded = enabled
+	}
+}
+
+// PrintOptionQRCode prints the token as a QRCode.
+func PrintOptionQRCode(enabled bool) PrintOption {
+	return func(cfg *printCfg) {
+		cfg.qrcode = enabled
+	}
+}
+
+// Fprint prints the given token string using
+// the methods passed as options in the given io.Writer.
+// If you pass no option, this function is a noop
+func Fprint(w io.Writer, token string, opts ...PrintOption) error {
+
+	cfg := printCfg{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	var addLine bool
+
+	if cfg.decoded {
+		if err := printDecoded(w, token); err != nil {
+			return err
+		}
+		addLine = true
+	}
+
+	if cfg.qrcode {
+		if addLine {
+			fmt.Fprintln(w)
+		}
+		printQRCode(w, token)
+		addLine = true
+	}
+
+	if cfg.raw {
+		if addLine {
+			fmt.Fprintln(w)
+		}
+		printRaw(w, token)
+	}
+
+	return nil
+}
+
+func printDecoded(w io.Writer, token string) error {
+
+	claims := jwt.MapClaims{}
+	p := jwt.Parser{}
+
+	t, _, err := p.ParseUnverified(token, &claims)
+	if err != nil {
+		return err
+	}
+
+	data, err := prettyjson.Marshal(claims)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(w, "alg:", t.Method.Alg())
+	fmt.Fprintln(w, "kid:", t.Header["kid"])
+	if exp, ok := claims["exp"].(float64); ok {
+		remaining := time.Until(time.Unix(int64(exp), 0))
+		if remaining <= 0 {
+			fmt.Fprintln(w, "exp: the token has expired", -remaining.Truncate(time.Second), "ago")
+		} else {
+			fmt.Fprintln(w, "exp:", remaining.Truncate(time.Second))
+		}
+	}
+	fmt.Fprintln(w, string(data))
+
+	return nil
+}
+
+func printQRCode(w io.Writer, token string) {
+
+	qrterminal.GenerateWithConfig(
+		token,
+		qrterminal.Config{
+			Writer:         w,
+			Level:          qrterminal.M,
+			HalfBlocks:     true,
+			QuietZone:      1,
+			BlackChar:      qrterminal.BLACK_BLACK,
+			WhiteBlackChar: qrterminal.WHITE_BLACK,
+			WhiteChar:      qrterminal.WHITE_WHITE,
+			BlackWhiteChar: qrterminal.BLACK_WHITE,
+		},
+	)
+}
+
+func printRaw(w io.Writer, token string) {
+	fmt.Fprintln(w, token)
+}

--- a/pkgs/token/print_test.go
+++ b/pkgs/token/print_test.go
@@ -1,0 +1,28 @@
+package token
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestOptions(t *testing.T) {
+
+	Convey("PrintOptionRaw should work", t, func() {
+		cfg := printCfg{}
+		PrintOptionRaw(true)(&cfg)
+		So(cfg.raw, ShouldBeTrue)
+	})
+
+	Convey("PrintOptionDecoded should work", t, func() {
+		cfg := printCfg{}
+		PrintOptionDecoded(true)(&cfg)
+		So(cfg.decoded, ShouldBeTrue)
+	})
+
+	Convey("PrintOptionQRCode should work", t, func() {
+		cfg := printCfg{}
+		PrintOptionQRCode(true)(&cfg)
+		So(cfg.qrcode, ShouldBeTrue)
+	})
+}


### PR DESCRIPTION
This patch refactors the mess that was token printing in a3sctl by
adding token.Fprint function.
