### PR TITLE
Align examples/python/testapp/init.sh token names to README

### DIFF
--- a/examples/python/testapp/init.sh
+++ b/examples/python/testapp/init.sh
@@ -52,7 +52,7 @@ echo
 echo "Here is a command to get a token for john:"
 echo
 cat <<EOF
-	export jtok=\$( \\
+	export TOKEN_J=\$( \\
 		a3sctl auth mtls \\
 			--api $A3SCTL_API \\
 			--api-skip-verify \\
@@ -67,7 +67,7 @@ echo
 echo "Here is a command to get a token for michael:"
 echo
 cat <<EOF
-	export mtok=\$( \\
+	export TOKEN_M=\$( \\
 		a3sctl auth mtls \\
 			--api $A3SCTL_API \\
 			--api-skip-verify \\


### PR DESCRIPTION
## Description

The provided example commands at the end of examples/python/testapp/init.sh call the tokens mtok and jtok.

This conflicts with the naming convention in examples/python/testapp/README.md.

## Motivation and Context

This change renames them TOKEN_M and TOKEN_J to make this more consistent and help avoid confusion.

## How Has This Been Tested?

This is a non-breaking change and therefore is untested.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
