### PR TITLE
Update: Add Delete function for nscache

### DIFF
--- a/cmd/a3s/conf.go
+++ b/cmd/a3s/conf.go
@@ -17,7 +17,7 @@ import (
 type Conf struct {
 	Init               bool   `mapstructure:"init"              desc:"If set, initialize the root permissions using the CAs passed in --init-root-ca and --init-platform-ca"`
 	InitContinue       bool   `mapstructure:"init-continue"     desc:"Continues normal boot after init."`
-	InitPlatformCAPath string `mapstructure:"init-platform-ca"  desc:"Path to the root CA to use to initialize root permissions"`
+	InitPlatformCAPath string `mapstructure:"init-platform-ca"  desc:"Path to the platform CA to use to initialize platform permissions"`
 	InitRootUserCAPath string `mapstructure:"init-root-ca"      desc:"Path to the root CA to use to initialize root permissions"`
 
 	JWT        JWTConf        `mapstructure:",squash"`

--- a/pkgs/nscache/nscache.go
+++ b/pkgs/nscache/nscache.go
@@ -45,6 +45,12 @@ func (c *NamespacedCache) Get(namespace string, key string) *ccache.Item {
 	return c.cache.Get(namespace + ":" + key)
 }
 
+// Delete attempts to delete an item from the cache using the given namespace and key.
+func (c *NamespacedCache) Delete(namespace string, key string) bool {
+
+	return c.cache.Delete(namespace + ":" + key)
+}
+
 // Start starts listening to notifications for automatic invalidation
 func (c *NamespacedCache) Start(ctx context.Context) {
 
@@ -56,12 +62,6 @@ func (c *NamespacedCache) Start(ctx context.Context) {
 			c.cleanupCacheForNamespace(msg.Data.(string))
 		},
 	)
-}
-
-// Delete attempts to delete an item from the cache using the given key.
-func (c *NamespacedCache) Delete(key string) bool {
-
-	return c.cache.Delete(key)
 }
 
 func (c *NamespacedCache) cleanupCacheForNamespace(ns string) {

--- a/pkgs/nscache/nscache.go
+++ b/pkgs/nscache/nscache.go
@@ -58,6 +58,12 @@ func (c *NamespacedCache) Start(ctx context.Context) {
 	)
 }
 
+// Delete attempts to delete an item from the cache using the given key.
+func (c *NamespacedCache) Delete(key string) bool {
+
+	return c.cache.Delete(key)
+}
+
 func (c *NamespacedCache) cleanupCacheForNamespace(ns string) {
 
 	suffix := "/"

--- a/pkgs/nscache/nscache_test.go
+++ b/pkgs/nscache/nscache_test.go
@@ -75,5 +75,29 @@ func TestCacheBehavior(t *testing.T) {
 			So(cache.Get("/hello/world/cool", "user1"), ShouldBeNil)
 			So(cache.Get("/hello/world/cool", "user2"), ShouldBeNil)
 		})
+
+		Convey("When I delete a full key directly from the cache should no longer have a value", func() {
+
+			success := cache.Delete("/hello/world/cool:user2")
+
+			So(success, ShouldBeTrue)
+
+			So(cache.Get("/hello", "").Value(), ShouldEqual, "hello0")
+			So(cache.Get("/hello/world", "").Value(), ShouldEqual, "hello1")
+			So(cache.Get("/hello/world/cool", "user1").Value(), ShouldEqual, "hello2")
+			So(cache.Get("/hello/world/cool", "user2"), ShouldBeNil)
+		})
+
+		Convey("When I try to delete a non-existant key directly from the cache, all values should still exist", func() {
+
+			success := cache.Delete("/hello/world/cool:user3")
+
+			So(success, ShouldBeFalse)
+
+			So(cache.Get("/hello", "").Value(), ShouldEqual, "hello0")
+			So(cache.Get("/hello/world", "").Value(), ShouldEqual, "hello1")
+			So(cache.Get("/hello/world/cool", "user1").Value(), ShouldEqual, "hello2")
+			So(cache.Get("/hello/world/cool", "user2").Value(), ShouldEqual, "hello3")
+		})
 	})
 }

--- a/pkgs/nscache/nscache_test.go
+++ b/pkgs/nscache/nscache_test.go
@@ -88,7 +88,7 @@ func TestCacheBehavior(t *testing.T) {
 			So(cache.Get("/hello/world/cool", "user2"), ShouldBeNil)
 		})
 
-		Convey("When I try to delete a non-existant key directly from the cache, all values should still exist", func() {
+		Convey("When I try to delete a non-existent key directly from the cache, all values should still exist", func() {
 
 			success := cache.Delete("/hello/world/cool:user3")
 

--- a/pkgs/nscache/nscache_test.go
+++ b/pkgs/nscache/nscache_test.go
@@ -78,7 +78,7 @@ func TestCacheBehavior(t *testing.T) {
 
 		Convey("When I delete a full key directly from the cache should no longer have a value", func() {
 
-			success := cache.Delete("/hello/world/cool:user2")
+			success := cache.Delete("/hello/world/cool", "user2")
 
 			So(success, ShouldBeTrue)
 
@@ -90,7 +90,7 @@ func TestCacheBehavior(t *testing.T) {
 
 		Convey("When I try to delete a non-existent key directly from the cache, all values should still exist", func() {
 
-			success := cache.Delete("/hello/world/cool:user3")
+			success := cache.Delete("/hello/world/cool", "user3")
 
 			So(success, ShouldBeFalse)
 


### PR DESCRIPTION
#### Description
While migrating backend to use a3s conventions, it was worth porting over the Delete function to allow nscache to expand its notification triggers as needed (eg. for automation action/condition).