### PR TITLE
new: support for initial provisionning data

### DIFF
--- a/cmd/a3s/conf.go
+++ b/cmd/a3s/conf.go
@@ -19,6 +19,7 @@ type Conf struct {
 	InitContinue       bool   `mapstructure:"init-continue"     desc:"Continues normal boot after init."`
 	InitPlatformCAPath string `mapstructure:"init-platform-ca"  desc:"Path to the platform CA to use to initialize platform permissions"`
 	InitRootUserCAPath string `mapstructure:"init-root-ca"      desc:"Path to the root CA to use to initialize root permissions"`
+	InitData           string `mapstructure:"init-data"         desc:"Path to an import file containing initial provisionning data"`
 
 	JWT        JWTConf        `mapstructure:",squash"`
 	MTLSHeader MTLSHeaderConf `mapstructure:",squash"`

--- a/cmd/a3s/main.go
+++ b/cmd/a3s/main.go
@@ -510,12 +510,12 @@ func initData(ctx context.Context, m manipulate.Manipulator, dataPath string) (b
 
 	data, err := os.ReadFile(dataPath)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("unable to read init import file: %w", err)
 	}
 
 	importFile := api.NewImport()
 	if err := yaml.Unmarshal(data, importFile); err != nil {
-		return false, err
+		return false, fmt.Errorf("unable to unmarshal import file: %w", err)
 	}
 
 	values := []elemental.Identifiables{
@@ -554,7 +554,7 @@ func initData(ctx context.Context, m manipulate.Manipulator, dataPath string) (b
 			lst,
 			false,
 		); err != nil {
-			return false, err
+			return false, fmt.Errorf("unable to import '%s': %w", lst.Identity().Name, err)
 		}
 	}
 

--- a/cmd/a3s/main.go
+++ b/cmd/a3s/main.go
@@ -528,9 +528,23 @@ func initData(ctx context.Context, m manipulate.Manipulator, dataPath string) (b
 	}
 
 	for _, lst := range values {
+		for i, o := range lst.List() {
+			if o.(elemental.Namespaceable).GetNamespace() == "" {
+				return false, fmt.Errorf(
+					"missing namespace property for object '%s' at index %d ",
+					lst.Identity().Name,
+					i,
+				)
+			}
+		}
+	}
+
+	for _, lst := range values {
+
 		if len(lst.List()) == 0 {
 			continue
 		}
+
 		if err := importing.Import(
 			ctx,
 			api.Manager(),


### PR DESCRIPTION
Adds --init-data to allow ops to pass an import file to initialize the system with default provisionning policies