### PR TITLE
Fixed: Allow dashes in namespaces and fix a fatal message

### DIFF
--- a/pkgs/api/doc/documentation.md
+++ b/pkgs/api/doc/documentation.md
@@ -1536,7 +1536,7 @@ Type: `string`
 
 The description of the object.
 
-##### `name` [`required`,`creation_only`,`format=^[a-zA-Z0-9_/]+$`]
+##### `name` [`required`,`creation_only`,`format=^[a-zA-Z0-9-_/]+$`]
 
 Type: `string`
 

--- a/pkgs/api/namespace.go
+++ b/pkgs/api/namespace.go
@@ -364,7 +364,7 @@ func (o *Namespace) Validate() error {
 		requiredErrors = requiredErrors.Append(err)
 	}
 
-	if err := elemental.ValidatePattern("name", o.Name, `^[a-zA-Z0-9_/]+$`, `must only contain alpha numerical characters, '-' or '_'`, true); err != nil {
+	if err := elemental.ValidatePattern("name", o.Name, `^[a-zA-Z0-9-_/]+$`, `must only contain alpha numerical characters, '-' or '_'`, true); err != nil {
 		errors = errors.Append(err)
 	}
 
@@ -448,7 +448,7 @@ var NamespaceAttributesMap = map[string]elemental.AttributeSpecification{
 		Type:           "string",
 	},
 	"Name": {
-		AllowedChars:   `^[a-zA-Z0-9_/]+$`,
+		AllowedChars:   `^[a-zA-Z0-9-_/]+$`,
 		AllowedChoices: []string{},
 		BSONFieldName:  "name",
 		ConvertedName:  "Name",
@@ -536,7 +536,7 @@ var NamespaceLowerCaseAttributesMap = map[string]elemental.AttributeSpecificatio
 		Type:           "string",
 	},
 	"name": {
-		AllowedChars:   `^[a-zA-Z0-9_/]+$`,
+		AllowedChars:   `^[a-zA-Z0-9-_/]+$`,
 		AllowedChoices: []string{},
 		BSONFieldName:  "name",
 		ConvertedName:  "Name",

--- a/pkgs/api/specs/namespace.spec
+++ b/pkgs/api/specs/namespace.spec
@@ -42,7 +42,7 @@ attributes:
     stored: true
     required: true
     creation_only: true
-    allowed_chars: ^[a-zA-Z0-9_/]+$
+    allowed_chars: ^[a-zA-Z0-9-_/]+$
     allowed_chars_message: must only contain alpha numerical characters, '-' or '_'
     example_value: mycompany
     getter: true

--- a/pkgs/bootstrap/clients.go
+++ b/pkgs/bootstrap/clients.go
@@ -97,7 +97,7 @@ func MakeMongoManipulator(cfg conf.MongoConf, hasher sharder.Hasher, additionalO
 
 	tlscfg, err := cfg.TLSConfig()
 	if err != nil {
-		zap.L().Fatal("Unable to prepare TLS config for nats", zap.Error(err))
+		zap.L().Fatal("Unable to prepare TLS config for mongodb", zap.Error(err))
 	}
 
 	if tlscfg != nil {


### PR DESCRIPTION
## Description
During testing I noticed the following error when creating a namespace with a dash (`-`):
```
error 422 (elemental): Validation Error: Data 'a3s-test' of attribute 'name' must only contain alpha numerical characters, '-' or '_'
```
This was due to the regex missing the support for dash. Mimic'd the same regex from gaia namespace and regenerated files.

Also, while bringing up a3s with shared backend, I noticed a fatal that was misleading. Fixed it as well. ;)