### PR TITLE
New: Add optional database initialization step

### DIFF
--- a/cmd/a3s/conf.go
+++ b/cmd/a3s/conf.go
@@ -16,6 +16,7 @@ import (
 // Conf holds the main configuration flags.
 type Conf struct {
 	Init               bool   `mapstructure:"init"              desc:"If set, initialize the root permissions using the CAs passed in --init-root-ca and --init-platform-ca"`
+	InitDB             bool   `mapstructure:"init-db"           desc:"If set, initialize the database using the mongo config passed in"`
 	InitContinue       bool   `mapstructure:"init-continue"     desc:"Continues normal boot after init."`
 	InitPlatformCAPath string `mapstructure:"init-platform-ca"  desc:"Path to the platform CA to use to initialize platform permissions"`
 	InitRootUserCAPath string `mapstructure:"init-root-ca"      desc:"Path to the root CA to use to initialize root permissions"`

--- a/cmd/a3s/conf.go
+++ b/cmd/a3s/conf.go
@@ -17,8 +17,8 @@ import (
 type Conf struct {
 	Init               bool   `mapstructure:"init"              desc:"If set, initialize the root permissions using the CAs passed in --init-root-ca and --init-platform-ca"`
 	InitContinue       bool   `mapstructure:"init-continue"     desc:"Continues normal boot after init."`
-	InitDB             bool   `mapstructure:"init-db"           desc:"If set, initialize the database using the mongo config passed in and init-db-name"`
-	InitDBUsername     string `mapstructure:"init-db-username"  desc:"If init-db is set, this will define the common name to use on db initialization"    default:"CN=a3s,OU=root,O=system"`
+	InitDB             bool   `mapstructure:"init-db"           desc:"If set, initialize the database using the mongo config passed in and init-db-username"`
+	InitDBUsername     string `mapstructure:"init-db-username"  desc:"If init-db is set, this will define the username to use on db initialization"           default:"CN=a3s,OU=root,O=system"`
 	InitPlatformCAPath string `mapstructure:"init-platform-ca"  desc:"Path to the platform CA to use to initialize platform permissions"`
 	InitRootUserCAPath string `mapstructure:"init-root-ca"      desc:"Path to the root CA to use to initialize root permissions"`
 	InitData           string `mapstructure:"init-data"         desc:"Path to an import file containing initial provisionning data"`

--- a/cmd/a3s/conf.go
+++ b/cmd/a3s/conf.go
@@ -16,8 +16,9 @@ import (
 // Conf holds the main configuration flags.
 type Conf struct {
 	Init               bool   `mapstructure:"init"              desc:"If set, initialize the root permissions using the CAs passed in --init-root-ca and --init-platform-ca"`
-	InitDB             bool   `mapstructure:"init-db"           desc:"If set, initialize the database using the mongo config passed in"`
 	InitContinue       bool   `mapstructure:"init-continue"     desc:"Continues normal boot after init."`
+	InitDB             bool   `mapstructure:"init-db"           desc:"If set, initialize the database using the mongo config passed in and init-db-name"`
+	InitDBUsername     string `mapstructure:"init-db-username"  desc:"If init-db is set, this will define the common name to use on db initialization"    default:"CN=a3s,OU=root,O=system"`
 	InitPlatformCAPath string `mapstructure:"init-platform-ca"  desc:"Path to the platform CA to use to initialize platform permissions"`
 	InitRootUserCAPath string `mapstructure:"init-root-ca"      desc:"Path to the root CA to use to initialize root permissions"`
 	InitData           string `mapstructure:"init-data"         desc:"Path to an import file containing initial provisionning data"`

--- a/cmd/a3s/main.go
+++ b/cmd/a3s/main.go
@@ -68,7 +68,7 @@ func main() {
 	}
 
 	if cfg.InitDB {
-		if err := createMongoDBAccount(cfg.MongoConf); err != nil {
+		if err := createMongoDBAccount(cfg.MongoConf, cfg.InitDBUsername); err != nil {
 			zap.L().Fatal("Unable to create mongodb account", zap.Error(err))
 		}
 
@@ -337,14 +337,13 @@ func main() {
 	server.Run(ctx)
 }
 
-func createMongoDBAccount(cfg conf.MongoConf) error {
+func createMongoDBAccount(cfg conf.MongoConf, username string) error {
 
 	m := bootstrap.MakeMongoManipulator(cfg, &hasher.Hasher{})
 
 	db, close, _ := manipmongo.GetDatabase(m)
 	defer close()
 
-	username := "CN=a3s,OU=root,O=system"
 	user := mgo.User{
 		Username: username,
 		OtherDBRoles: map[string][]mgo.Role{


### PR DESCRIPTION
#### Description
For CI and production deployments, we need a way for us to initialize the database before a3s starts. This PR will house the changes needed to achieve this.