### PR TITLE
pkgs/nscache: added option system + OptionNotificationName

### DIFF
--- a/pkgs/nscache/options.go
+++ b/pkgs/nscache/options.go
@@ -15,7 +15,7 @@ type Option func(*config)
 
 // OptionNotificationName allows to change the notification name
 // used to listen to namespace changes from the pubsub.
-// This defaults to OptionNotificationName,
+// This defaults to NotificationNamespaceChanges,
 func OptionNotificationName(name string) Option {
 	return func(c *config) {
 		c.notificationName = name

--- a/pkgs/nscache/options.go
+++ b/pkgs/nscache/options.go
@@ -1,0 +1,23 @@
+package nscache
+
+type config struct {
+	notificationName string
+}
+
+func newConfig() config {
+	return config{
+		notificationName: NotificationNamespaceChanges,
+	}
+}
+
+// Option represents a parametric option for the nscache.
+type Option func(*config)
+
+// OptionNotificationName allows to change the notification name
+// used to listen to namespace changes from the pubsub.
+// This defaults to OptionNotificationName,
+func OptionNotificationName(name string) Option {
+	return func(c *config) {
+		c.notificationName = name
+	}
+}

--- a/pkgs/nscache/options_test.go
+++ b/pkgs/nscache/options_test.go
@@ -1,0 +1,22 @@
+package nscache
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestOption(t *testing.T) {
+
+	Convey("Given a new config", t, func() {
+
+		c := newConfig()
+
+		So(c.notificationName, ShouldEqual, NotificationNamespaceChanges)
+
+		Convey("OptionNotificationName should work", func() {
+			OptionNotificationName("coucou")(&c)
+			So(c.notificationName, ShouldEqual, "coucou")
+		})
+	})
+}


### PR DESCRIPTION
Add Option system and OptionNotificationName to nscache. OptionNotificationName allows to change the notification name used to listen for namespace events.