### PR TITLE
Fixed: Only populate issuer if one is found

### DIFF
--- a/pkgs/permissions/retriever.go
+++ b/pkgs/permissions/retriever.go
@@ -213,11 +213,13 @@ func makeAPIAuthorizationPolicyRetrieveFilter(claims []string) *elemental.Filter
 
 	filter := elemental.NewFilterComposer().
 		WithKey("flattenedsubject").In(itags...).
-		WithKey("trustedissuers").Contains(issuer).
-		WithKey("disabled").Equals(false).
-		Done()
+		WithKey("disabled").Equals(false)
 
-	return filter
+	if issuer != "" {
+		filter.WithKey("trustedissuers").Contains(issuer)
+	}
+
+	return filter.Done()
 }
 
 // countNamespace tries to find the namespace in a two step process.

--- a/pkgs/permissions/retriever_test.go
+++ b/pkgs/permissions/retriever_test.go
@@ -107,7 +107,7 @@ func TestIsAuthorizedWithToken(t *testing.T) {
 
 			So(err, ShouldBeNil)
 			So(perms.Allows("get", "things"), ShouldEqual, true)
-			So(expectedFilter.String(), ShouldEqual, `flattenedsubject in ["color=blue", "@issuer=toto"] and trustedissuers contains ["toto"] and disabled == false`)
+			So(expectedFilter.String(), ShouldEqual, `flattenedsubject in ["color=blue", "@issuer=toto"] and disabled == false and trustedissuers contains ["toto"]`)
 		})
 
 		Convey("When there is a policy matching twice using twice the same set", func() {


### PR DESCRIPTION
#### Description
When leveraging a3s as an auth source, I noticed that claims coming from backend looked like this:
```
"claims": [
  "@auth:account=account-837b0b8d-6a14-4cb8-a11d-97a03fafe6c6",
  "@auth:email=user@account-837b0b8d-6a14-4cb8-a11d-97a03fafe6c6.com",
  "@auth:id=6357a6d0a76fe8b13709d736",
  "@auth:organization=account-837b0b8d-6a14-4cb8-a11d-97a03fafe6c6",
  "@auth:realm=vince",
  "@auth:subject=account-837b0b8d-6a14-4cb8-a11d-97a03fafe6c6"
]
```
This caused issue with the retrievemany filter for authorizations as there was no issuer provided. To get it to work, the logic is now to populate the issuer if one is found, else skip adding it.