### PR TITLE
New: Add operation transformer

### DIFF
--- a/pkgs/authorizer/operationtransformer.go
+++ b/pkgs/authorizer/operationtransformer.go
@@ -1,0 +1,8 @@
+package authorizer
+
+import "go.aporeto.io/elemental"
+
+// A OperationTransformer is an interface that can transform the operation being evaluated.
+type OperationTransformer interface {
+	Transform(operation elemental.Operation) string
+}

--- a/pkgs/authorizer/operationtransformer_mock.go
+++ b/pkgs/authorizer/operationtransformer_mock.go
@@ -1,0 +1,66 @@
+package authorizer
+
+import (
+	"sync"
+	"testing"
+
+	"go.aporeto.io/elemental"
+)
+
+type mockedOperationTransformerMethods struct {
+	transformMock func(elemental.Operation) string
+}
+
+// A MockOperationTransformer allows to mock a transform.OperationTransformer for unit tests.
+type MockOperationTransformer interface {
+	OperationTransformer
+	MockTransform(t *testing.T, impl func(elemental.Operation) string)
+}
+
+type mockOperationTransformer struct {
+	mocks       map[*testing.T]*mockedOperationTransformerMethods
+	currentTest *testing.T
+
+	sync.Mutex
+}
+
+// NewMockOperationTransformer returns a MockOperationTransformer.
+func NewMockOperationTransformer() MockOperationTransformer {
+	return &mockOperationTransformer{
+		mocks: map[*testing.T]*mockedOperationTransformerMethods{},
+	}
+}
+
+// MockTransform replaces the Transform implementation with the given function.
+func (r *mockOperationTransformer) MockTransform(t *testing.T, impl func(elemental.Operation) string) {
+
+	r.Lock()
+	defer r.Unlock()
+
+	r.currentMocks(t).transformMock = impl
+}
+
+func (r *mockOperationTransformer) Transform(operation elemental.Operation) string {
+
+	r.Lock()
+	defer r.Unlock()
+
+	if mock := r.currentMocks(r.currentTest); mock != nil && mock.transformMock != nil {
+		return mock.transformMock(operation)
+	}
+
+	return ""
+}
+
+func (r *mockOperationTransformer) currentMocks(t *testing.T) *mockedOperationTransformerMethods {
+
+	mocks := r.mocks[t]
+
+	if mocks == nil {
+		mocks = &mockedOperationTransformerMethods{}
+		r.mocks[t] = mocks
+	}
+
+	r.currentTest = t
+	return mocks
+}

--- a/pkgs/authorizer/operationtransformer_mock_test.go
+++ b/pkgs/authorizer/operationtransformer_mock_test.go
@@ -1,0 +1,33 @@
+package authorizer
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/elemental"
+)
+
+func TestMockOperationTransformer(t *testing.T) {
+
+	Convey("Given a MockOperationTransformer and an elemental operation", t, func() {
+
+		mockOperationTransformer := NewMockOperationTransformer()
+
+		operation := elemental.OperationRetrieveMany
+
+		Convey("Calling Transform without mock should work", func() {
+			op := mockOperationTransformer.Transform(operation)
+			So(op, ShouldNotBeNil)
+			So(len(op), ShouldEqual, 0)
+		})
+
+		Convey("Calling Transform with mock should work", func() {
+			mockOperationTransformer.MockTransform(t, func(elemental.Operation) string {
+				return "get"
+			})
+			op := mockOperationTransformer.Transform(operation)
+			So(op, ShouldNotBeNil)
+			So(op, ShouldEqual, "get")
+		})
+	})
+}

--- a/pkgs/authorizer/options.go
+++ b/pkgs/authorizer/options.go
@@ -3,7 +3,8 @@ package authorizer
 import "go.aporeto.io/a3s/pkgs/permissions"
 
 type config struct {
-	ignoredResources []string
+	ignoredResources     []string
+	operationTransformer OperationTransformer
 }
 
 // An Option can be used to configure various options in the Authorizer.
@@ -13,6 +14,13 @@ type Option func(*config)
 func OptionIgnoredResources(identities ...string) Option {
 	return func(cfg *config) {
 		cfg.ignoredResources = identities
+	}
+}
+
+// OptionOperationTransformer sets operation transformer to apply to each operation.
+func OptionOperationTransformer(t OperationTransformer) Option {
+	return func(cfg *config) {
+		cfg.operationTransformer = t
 	}
 }
 

--- a/pkgs/authorizer/options_test.go
+++ b/pkgs/authorizer/options_test.go
@@ -14,6 +14,13 @@ func TestOption(t *testing.T) {
 		OptionIgnoredResources("r1", "r2")(cfg)
 		So(cfg.ignoredResources, ShouldResemble, []string{"r1", "r2"})
 	})
+
+	Convey("OptionOperationTransformer should work", t, func() {
+		cfg := &config{}
+		t := NewMockOperationTransformer()
+		OptionOperationTransformer(t)(cfg)
+		So(cfg.operationTransformer, ShouldResemble, t)
+	})
 }
 
 func TestOptionCheck(t *testing.T) {


### PR DESCRIPTION
#### Description
Since the authorizer uses `elemental.Operation` type for its operations with checking authorization, this means we need a transformer if we want to use other terminology. To achieve such, this PR will add an option to optionally pass in an operation transformer to handle compatibility.