### PR TITLE
pkgs/orphans: adds orphaned recovery deletion job

### DIFF
--- a/cmd/a3s/conf.go
+++ b/cmd/a3s/conf.go
@@ -16,7 +16,6 @@ import (
 var (
 	version = "v0.0.0"
 	commit  = "dev"
-	date    = ""
 )
 
 // Conf holds the main configuration flags.

--- a/pkgs/jobs/orphans.go
+++ b/pkgs/jobs/orphans.go
@@ -1,0 +1,102 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"go.aporeto.io/a3s/pkgs/api"
+	"go.aporeto.io/elemental"
+	"go.aporeto.io/manipulate"
+	"go.uber.org/zap"
+)
+
+var (
+	orphanCleaningAdjustment = time.Duration(rand.Intn(60)) * time.Second
+)
+
+// ScheduleOrphanedObjectsDeleteJob periodically cleans objects that lives in a
+// deleted namespace. It takes 2 manipulators. The first one is used to perform
+// object cleanup in the database. The other is used to retrieve the list of
+// existing namespaces. The job will remove all the identities provided by the
+// given model manager that have a package set to the given packageName. If
+// package name is set to *, the job will apply to all identities The job will
+// run at the defined period + a random duration between 0 and 1 minute.
+func ScheduleOrphanedObjectsDeleteJob(
+	ctx context.Context,
+	nsm manipulate.Manipulator,
+	m manipulate.TransactionalManipulator,
+	identities []elemental.Identity,
+	period time.Duration,
+) {
+
+	ticker := time.NewTicker(period + orphanCleaningAdjustment)
+	defer ticker.Stop()
+
+	for {
+		select {
+
+		case <-ticker.C:
+			if err := DeleteOrphanedObjects(ctx, nsm, m, identities); err != nil {
+				zap.L().Error(
+					"Unable to complete job DeleteOrphanedObjects",
+					zap.Error(err),
+				)
+			}
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// DeleteOrphanedObjects deletes the objects with the given
+// identities that are not in any of the given namespaces.
+func DeleteOrphanedObjects(
+	ctx context.Context,
+	apiManipulator manipulate.Manipulator,
+	m manipulate.TransactionalManipulator,
+	identities []elemental.Identity,
+) error {
+
+	os, err := manipulate.Iter(
+		ctx,
+		apiManipulator,
+		manipulate.NewContext(
+			ctx,
+			manipulate.ContextOptionRecursive(true),
+			manipulate.ContextOptionOrder("ID"),
+			manipulate.ContextOptionFields([]string{"name"}),
+		),
+		api.SparseNamespacesList{},
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve list of namespaces: %w", err)
+	}
+
+	namespaces := os.List()
+	names := make([]interface{}, len(namespaces)+1)
+	names[0] = "/"
+	for i, ns := range namespaces {
+		names[i+1] = *(ns.(*api.SparseNamespace).Name)
+	}
+
+	mctx := manipulate.NewContext(
+		ctx,
+		manipulate.ContextOptionFilter(
+			elemental.NewFilterComposer().
+				WithKey("namespace").NotIn(names...).
+				Done(),
+		),
+	)
+
+	for _, i := range identities {
+		if err := m.DeleteMany(mctx.Derive(), i); err != nil {
+			return fmt.Errorf("unable to deletemany '%s': %w", i.Category, err)
+		}
+	}
+
+	return nil
+}

--- a/pkgs/jobs/orphans_test.go
+++ b/pkgs/jobs/orphans_test.go
@@ -141,6 +141,5 @@ func TestDeleteOrphanedJobs(t *testing.T) {
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldEqual, "unable to deletemany 'lists': bim")
 		})
-
 	})
 }

--- a/pkgs/jobs/orphans_test.go
+++ b/pkgs/jobs/orphans_test.go
@@ -1,0 +1,146 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/a3s/pkgs/api"
+	"go.aporeto.io/elemental"
+	testmodel "go.aporeto.io/elemental/test/model"
+	"go.aporeto.io/manipulate"
+	"go.aporeto.io/manipulate/maniptest"
+)
+
+func TestDeleteOrphanedJobs(t *testing.T) {
+
+	Convey("I have some manipulators and a model", t, func() {
+
+		m1 := maniptest.NewTestManipulator()
+		m2 := maniptest.NewTestManipulator()
+		makeStrPr := func(str string) *string { return &str }
+
+		Convey("everything works fine", func() {
+
+			var m1ExpectedRecursive bool
+			var m1ExpectedFields []string
+			var m1ExpectedOrder []string
+			m1.MockRetrieveMany(t, func(mctx manipulate.Context, dest elemental.Identifiables) error {
+
+				m1ExpectedRecursive = mctx.Recursive()
+				m1ExpectedFields = mctx.Fields()
+				m1ExpectedOrder = mctx.Order()
+
+				*dest.(*api.SparseNamespacesList) = append(
+					*dest.(*api.SparseNamespacesList),
+					&api.SparseNamespace{
+						ID:   makeStrPr("1"),
+						Name: makeStrPr("/a"),
+					},
+					&api.SparseNamespace{
+						ID:   makeStrPr("2"),
+						Name: makeStrPr("/a/1"),
+					},
+					&api.SparseNamespace{
+						ID:   makeStrPr("3"),
+						Name: makeStrPr("/b"),
+					},
+				)
+				return nil
+			})
+
+			var m2ExpectedFiler *elemental.Filter
+			var m2ExpectedCalls int
+			m2.MockDeleteMany(t, func(mctx manipulate.Context, identity elemental.Identity) error {
+				m2ExpectedCalls++
+				m2ExpectedFiler = mctx.Filter()
+				return nil
+			})
+
+			err := DeleteOrphanedObjects(
+				context.Background(),
+				m1,
+				m2,
+				[]elemental.Identity{
+					testmodel.ListIdentity,
+					testmodel.TaskIdentity,
+				},
+			)
+
+			So(err, ShouldBeNil)
+			So(m1ExpectedRecursive, ShouldBeTrue)
+			So(m1ExpectedFields, ShouldResemble, []string{"name"})
+			So(m1ExpectedOrder, ShouldResemble, []string{"ID"})
+
+			So(m2ExpectedCalls, ShouldEqual, 2)
+			So(
+				m2ExpectedFiler,
+				ShouldResemble,
+				elemental.NewFilterComposer().
+					WithKey("namespace").NotIn("/", "/a", "/a/1", "/b").
+					Done(),
+			)
+		})
+
+		Convey("When m1 returns an error", func() {
+
+			m1.MockRetrieveMany(t, func(mctx manipulate.Context, dest elemental.Identifiables) error {
+				return fmt.Errorf("bim")
+			})
+
+			err := DeleteOrphanedObjects(
+				context.Background(),
+				m1,
+				m2,
+				[]elemental.Identity{
+					testmodel.ListIdentity,
+					testmodel.TaskIdentity,
+				},
+			)
+
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "unable to retrieve list of namespaces: unable to retrieve objects for iteration 1: bim")
+		})
+
+		Convey("When m2 returns an error", func() {
+
+			m1.MockRetrieveMany(t, func(mctx manipulate.Context, dest elemental.Identifiables) error {
+				*dest.(*api.SparseNamespacesList) = append(
+					*dest.(*api.SparseNamespacesList),
+					&api.SparseNamespace{
+						ID:   makeStrPr("1"),
+						Name: makeStrPr("/a"),
+					},
+					&api.SparseNamespace{
+						ID:   makeStrPr("2"),
+						Name: makeStrPr("/a/1"),
+					},
+					&api.SparseNamespace{
+						ID:   makeStrPr("3"),
+						Name: makeStrPr("/b"),
+					},
+				)
+				return nil
+			})
+
+			m2.MockDeleteMany(t, func(mctx manipulate.Context, identity elemental.Identity) error {
+				return fmt.Errorf("bim")
+			})
+
+			err := DeleteOrphanedObjects(
+				context.Background(),
+				m1,
+				m2,
+				[]elemental.Identity{
+					testmodel.ListIdentity,
+					testmodel.TaskIdentity,
+				},
+			)
+
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "unable to deletemany 'lists': bim")
+		})
+
+	})
+}


### PR DESCRIPTION
This pr adds the needed package to start the cleaning jobs for orphaned objects (objects living in a deleted namespace, with a missed push)