### PR TITLE
Enhancement: Adjust orphan cleanup job to scale with large number of namespaces

### DIFF
--- a/pkgs/jobs/orphans.go
+++ b/pkgs/jobs/orphans.go
@@ -96,6 +96,12 @@ func DeleteOrphanedObjects(
 	}
 
 	for _, i := range identities {
+
+		// Never run against namespaces as it is our source of truth
+		if i.Name == api.NamespaceIdentity.Name {
+			continue
+		}
+
 		if err = mgodb.C(i.Name).Pipe([]bson.M{
 			{
 				"$match": bson.M{
@@ -116,6 +122,12 @@ func DeleteOrphanedObjects(
 		if len(orphans) == 0 {
 			continue
 		}
+
+		zap.L().Debug("Deleting orphans",
+			zap.String("identity", i.Name),
+			zap.Int("count", len(orphans)),
+			zap.Reflect("orphans", orphans),
+		)
 
 		ids := make([]any, 0, len(orphans))
 		for _, orphan := range orphans {


### PR DESCRIPTION
#### Description
There is a scaling problem with our `DeleteOrphanedObjects` job. It currently cannot handle the large queries that are created from prod/staging platforms. The limit of 16MB per document can happen fairly easily once there are 1,000s/10,000s of namespaces.

The new approach is to leverage aggregate pipelines in mongodb to handle these large requests. It may be enough to just put the request in the pipeline to get past the 16MB document limit restriction, but regardless this approach can now easily break the request into multiple stages. Aggregate pipelines can handle up to 1000 stages before it hits a limit itself (with each stage allowing up to or past 16MB per stage): https://www.mongodb.com/docs/manual/core/aggregation-pipeline-limits/